### PR TITLE
Encode quotation marks in page content

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -14,7 +14,7 @@ export default function About() {
               <div className="md:col-span-2 space-y-6">
                 <div className="bg-card border border-border rounded-xl p-8 hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                   <p className="text-lg leading-relaxed text-card-foreground">
-                    I'm a Software & Digitalization Project Lead at Telsonic, creating customer specific automation
+                    I&apos;m a Software & Digitalization Project Lead at Telsonic, creating customer specific automation
                     workflows in business-critical systems.
                   </p>
                 </div>
@@ -28,7 +28,7 @@ export default function About() {
 
                 <div className="bg-card border border-border rounded-xl p-8 hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                   <p className="text-lg leading-relaxed text-card-foreground">
-                    I'm passionate about leveraging technology to drive efficiency and improve user experiences.
+                    I&apos;m passionate about leveraging technology to drive efficiency and improve user experiences.
                   </p>
                 </div>
 

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -16,10 +16,10 @@ export default function Contact() {
           <FadeInSection>
             <div className="text-center space-y-4">
               <h1 className="text-4xl md:text-6xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-                Let's Work Together
+                Let&apos;s Work Together
               </h1>
               <p className="text-xl text-muted-foreground max-w-2xl mx-auto font-serif">
-                Ready to bring your project to life? I'd love to hear about your ideas and discuss how we can make them
+                Ready to bring your project to life? I&apos;d love to hear about your ideas and discuss how we can make them
                 reality.
               </p>
             </div>
@@ -33,7 +33,7 @@ export default function Contact() {
                     <div>
                       <h3 className="text-2xl font-semibold mb-6">Get in Touch</h3>
                       <p className="text-lg text-muted-foreground leading-relaxed mb-8">
-                        I'm always interested in discussing new opportunities, innovative projects, or simply connecting
+                        I&apos;m always interested in discussing new opportunities, innovative projects, or simply connecting
                         with fellow professionals in the tech industry.
                       </p>
                     </div>
@@ -116,7 +116,7 @@ export default function Contact() {
             <div className="bg-gradient-to-r from-primary/10 to-secondary/10 rounded-2xl p-8 text-center">
               <h3 className="text-2xl font-bold mb-4">Prefer a Quick Chat?</h3>
               <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
-                Sometimes it's easier to discuss projects over a call. I'm available for brief consultations to
+                Sometimes it&apos;s easier to discuss projects over a call. I&apos;m available for brief consultations to
                 understand your needs better.
               </p>
               <button className="px-6 py-3 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-all duration-300 hover:scale-105 glow-effect">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
                 </div>
               </div>
               <h1 className="text-5xl md:text-7xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent leading-tight animate-in fade-in slide-in-from-bottom-4 duration-1000">
-                Hi, I'm Seya Weber
+                Hi, I&apos;m Seya Weber
               </h1>
               <p className="text-xl md:text-2xl text-muted-foreground max-w-2xl mx-auto leading-relaxed font-serif animate-in fade-in slide-in-from-bottom-4 duration-1000 delay-200">
                 Project Manager Software and Digitalisation in St. Gallen, Switzerland.
@@ -117,7 +117,7 @@ export default function Home() {
                   className="group bg-card border border-border rounded-xl p-8 hover:shadow-xl transition-all duration-300 hover:-translate-y-2 block"
                 >
                   <h3 className="text-xl font-semibold mb-4 group-hover:text-primary transition-colors">Projects</h3>
-                  <p className="text-muted-foreground mb-4">Discover the projects I've worked on and their impact.</p>
+                  <p className="text-muted-foreground mb-4">Discover the projects I&apos;ve worked on and their impact.</p>
                   <ArrowRight className="w-5 h-5 text-primary group-hover:translate-x-2 transition-transform duration-300" />
                 </Link>
               </InteractiveCard>


### PR DESCRIPTION
## Summary
- encode apostrophes in About page text
- encode apostrophes in Contact page text
- encode apostrophes in Home page text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a86822f60883278834bfd118e1c921