### PR TITLE
refactor: use next/image for images

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { JsonLd } from "../../../components/JsonLd"
 import { blogPosts } from "../../../src/config"
 import Link from "next/link"
 import { Calendar, Clock, ArrowLeft, Share2 } from "lucide-react"
+import Image from "next/image"
 import { Button } from "@/components/ui/button"
 
 interface BlogPostPageProps {
@@ -127,9 +128,11 @@ export default function BlogPost({ params }: BlogPostPageProps) {
 
           <FadeInSection>
             <div className="mb-12">
-              <img
+              <Image
                 src={`/abstract-geometric-shapes.png?height=400&width=800&query=${encodeURIComponent(post.title)}`}
                 alt={post.title}
+                width={800}
+                height={400}
                 className="w-full h-64 md:h-96 object-cover rounded-xl"
               />
             </div>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -7,6 +7,7 @@ import { InteractiveCard } from "../../components/InteractiveCard"
 import { blogPosts } from "../../src/config"
 import Link from "next/link"
 import { Calendar, Clock, ArrowRight } from "lucide-react"
+import Image from "next/image"
 
 export default function Blog() {
   return (
@@ -34,9 +35,11 @@ export default function Blog() {
                     <div className="md:flex">
                       <div className="md:w-1/3">
                         <div className="h-64 md:h-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center">
-                          <img
+                          <Image
                             src={`/abstract-geometric-shapes.png?height=300&width=400&query=${encodeURIComponent(post.title)}`}
                             alt={post.title}
+                            width={400}
+                            height={300}
                             className="w-full h-full object-cover"
                           />
                         </div>

--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -7,6 +7,7 @@ import FadeInSection from "../../../components/FadeInSection"
 import { caseStudies } from "../../../src/config"
 import Link from "next/link"
 import { ArrowLeft, Users, Clock, Building, CheckCircle, Quote } from "lucide-react"
+import Image from "next/image"
 
 interface CaseStudyPageProps {
   params: Promise<{ slug: string }>
@@ -74,9 +75,11 @@ export default function CaseStudy({ params }: CaseStudyPageProps) {
 
           <FadeInSection>
             <div className="mb-12">
-              <img
+              <Image
                 src={`/abstract-geometric-shapes.png?height=400&width=800&query=${encodeURIComponent(study.title)}`}
                 alt={study.title}
+                width={800}
+                height={400}
                 className="w-full h-64 md:h-96 object-cover rounded-xl"
               />
             </div>

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -7,6 +7,7 @@ import { InteractiveCard } from "../../components/InteractiveCard"
 import { caseStudies } from "../../src/config"
 import Link from "next/link"
 import { ArrowRight, Users, Clock, Building } from "lucide-react"
+import Image from "next/image"
 
 export default function CaseStudies() {
   return (
@@ -34,9 +35,11 @@ export default function CaseStudies() {
                     <div className="md:flex">
                       <div className="md:w-2/5">
                         <div className="h-64 md:h-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center">
-                          <img
+                          <Image
                             src={`/abstract-geometric-shapes.png?height=400&width=600&query=${encodeURIComponent(study.title)}`}
                             alt={study.title}
+                            width={600}
+                            height={400}
                             className="w-full h-full object-cover"
                           />
                         </div>

--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -33,6 +33,7 @@ import {
 import { newsFeeds, sharedFiles as initialSharedFiles } from "../../src/config"
 import type { Poll } from "@/lib/polls"
 import Navigation from "../../components/Navigation"
+import Image from "next/image"
 
 export default function HubPage() {
   const { user, isAuthenticated, isAdmin } = useAuth()
@@ -268,11 +269,12 @@ export default function HubPage() {
                       </div>
 
                       {post.image && (
-                        <div className="rounded-lg overflow-hidden">
-                          <img
+                        <div className="relative w-full h-48 rounded-lg overflow-hidden">
+                          <Image
                             src={post.image || "/placeholder.svg"}
                             alt={post.title}
-                            className="w-full h-48 object-cover hover:scale-105 transition-transform duration-300"
+                            fill
+                            className="object-cover hover:scale-105 transition-transform duration-300"
                           />
                         </div>
                       )}

--- a/components/LazyImage.tsx
+++ b/components/LazyImage.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react"
 import { LoadingSpinner } from "./LoadingSpinner"
+import Image from "next/image"
 
 interface LazyImageProps {
   src: string
@@ -16,7 +17,7 @@ export function LazyImage({ src, alt, className = "", width, height, priority = 
   const [isLoaded, setIsLoaded] = useState(false)
   const [isInView, setIsInView] = useState(priority)
   const [error, setError] = useState(false)
-  const imgRef = useRef<HTMLImageElement>(null)
+  const imgRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (priority) return
@@ -62,16 +63,14 @@ export function LazyImage({ src, alt, className = "", width, height, priority = 
       )}
 
       {isInView && (
-        <img
+        <Image
           src={src || "/placeholder.svg"}
           alt={alt}
-          width={width}
-          height={height}
           onLoad={handleLoad}
           onError={handleError}
-          className={`transition-opacity duration-300 ${isLoaded ? "opacity-100" : "opacity-0"} ${className}`}
           loading={priority ? "eager" : "lazy"}
-          decoding="async"
+          {...(width && height ? { width, height } : { fill: true })}
+          className={`transition-opacity duration-300 ${isLoaded ? "opacity-100" : "opacity-0"} ${className}`}
         />
       )}
     </div>

--- a/components/TestimonialCard.tsx
+++ b/components/TestimonialCard.tsx
@@ -1,4 +1,5 @@
 import { Quote } from "lucide-react"
+import Image from "next/image"
 
 interface TestimonialCardProps {
   quote: string
@@ -21,12 +22,14 @@ export default function TestimonialCard({ quote, name, role, company, avatar }: 
 
       <div className="flex items-center gap-4">
         <div className="w-12 h-12 rounded-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center overflow-hidden">
-          <img
+          <Image
             src={avatar || "/placeholder.svg"}
             alt={name}
+            width={48}
+            height={48}
             className="w-full h-full object-cover"
             onError={(e) => {
-              const target = e.target as HTMLImageElement
+              const target = e.currentTarget
               target.style.display = "none"
               target.nextElementSibling!.classList.remove("hidden")
             }}


### PR DESCRIPTION
## Summary
- replace HTML `img` tags with Next.js `Image`
- add explicit dimensions or fill for optimized images

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a86826b0a48327a1d8ff76e8816163