### PR TITLE
Improve shared file and poll typings with safer API errors

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -25,8 +25,9 @@ export async function POST(req: Request) {
     messages.push({ ...data, createdAt: new Date().toISOString() })
     await fs.writeFile(dataFile, JSON.stringify(messages, null, 2))
     return NextResponse.json({ success: true })
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("contact error", err)
-    return NextResponse.json({ success: false, error: err.message ?? "Invalid request" }, { status: 400 })
+    const message = err instanceof Error ? err.message : "Invalid request"
+    return NextResponse.json({ success: false, error: message }, { status: 400 })
   }
 }

--- a/app/api/polls/[id]/vote/route.ts
+++ b/app/api/polls/[id]/vote/route.ts
@@ -21,7 +21,8 @@ export async function POST(req: Request, { params }: Params) {
     poll.totalVotes += 1
     await writePolls(polls)
     return NextResponse.json(poll)
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message ?? "Invalid request" }, { status: 400 })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Invalid request"
+    return NextResponse.json({ error: message }, { status: 400 })
   }
 }

--- a/app/api/polls/route.ts
+++ b/app/api/polls/route.ts
@@ -13,7 +13,8 @@ export async function POST(req: Request) {
     polls.unshift(poll)
     await writePolls(polls)
     return NextResponse.json(poll, { status: 201 })
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message ?? "Invalid request" }, { status: 400 })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Invalid request"
+    return NextResponse.json({ error: message }, { status: 400 })
   }
 }

--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -34,11 +34,22 @@ import { newsFeeds, sharedFiles as initialSharedFiles } from "../../src/config"
 import type { Poll } from "@/lib/polls"
 import Navigation from "../../components/Navigation"
 
+export interface SharedFile {
+  id: string
+  name: string
+  size: string
+  type: string
+  uploadedBy: string
+  uploadedAt: string
+  downloads: number
+  url: string
+}
+
 export default function HubPage() {
   const { user, isAuthenticated, isAdmin } = useAuth()
   const router = useRouter()
   const [likedPosts, setLikedPosts] = useState<Set<string>>(new Set())
-  const [sharedFiles, setSharedFiles] = useState(initialSharedFiles)
+  const [sharedFiles, setSharedFiles] = useState<SharedFile[]>(initialSharedFiles as SharedFile[])
   const [fileSearchTerm, setFileSearchTerm] = useState("")
   const [fileTypeFilter, setFileTypeFilter] = useState("all")
   const [votingPolls, setVotingPolls] = useState<Poll[]>([])
@@ -67,7 +78,7 @@ export default function HubPage() {
     })
   }
 
-  const handleFileUploaded = (newFile: any) => {
+  const handleFileUploaded = (newFile: SharedFile) => {
     setSharedFiles((prev) => [newFile, ...prev])
   }
 

--- a/components/CreatePollModal.tsx
+++ b/components/CreatePollModal.tsx
@@ -9,11 +9,12 @@ import { Label } from "./ui/label"
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card"
 import { X, Plus, Trash2 } from "lucide-react"
 import { useAuth } from "./AuthProvider"
+import type { Poll, PollOption } from "@/lib/polls"
 
 interface CreatePollModalProps {
   isOpen: boolean
   onClose: () => void
-  onCreatePoll: (poll: any) => void
+  onCreatePoll: (poll: Poll) => void
 }
 
 export function CreatePollModal({ isOpen, onClose, onCreatePoll }: CreatePollModalProps) {
@@ -53,14 +54,14 @@ export function CreatePollModal({ isOpen, onClose, onCreatePoll }: CreatePollMod
     const endDate = new Date()
     endDate.setDate(endDate.getDate() + Number.parseInt(duration))
 
-    const newPoll = {
+    const newPoll: Poll = {
       id: Date.now().toString(),
       question: question.trim(),
       options: options.map((opt, index) => ({
         id: String.fromCharCode(97 + index), // a, b, c, etc.
         text: opt.trim(),
         votes: 0,
-      })),
+      })) as PollOption[],
       createdBy: user?.name || "Unknown",
       createdAt: new Date().toISOString(),
       endsAt: endDate.toISOString(),

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -1,16 +1,16 @@
 "use client"
 
 import type React from "react"
-
 import { useState, useRef } from "react"
 import { Button } from "./ui/button"
 import { Card, CardContent } from "./ui/card"
 import { Progress } from "./ui/progress"
 import { Upload, File, ImageIcon, FileText, Code } from "lucide-react"
 import { useAuth } from "./AuthProvider"
+import type { SharedFile } from "@/app/hub/page"
 
 interface FileUploadProps {
-  onFileUploaded: (file: any) => void
+  onFileUploaded: (file: SharedFile) => void
 }
 
 export function FileUpload({ onFileUploaded }: FileUploadProps) {
@@ -46,7 +46,7 @@ export function FileUpload({ onFileUploaded }: FileUploadProps) {
           setIsUploading(false)
 
           // Create file object and add to shared files
-          const newFile = {
+          const newFile: SharedFile = {
             id: Date.now().toString(),
             name: file.name,
             size: formatFileSize(file.size),


### PR DESCRIPTION
## Summary
- define a `SharedFile` interface for hub file sharing and use it across upload logic
- type poll creation props with `Poll` and `PollOption` interfaces
- handle API route errors by catching `unknown` and narrowing to `Error`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a86824bfe88327be42815c81ef1c54