### PR TITLE
Ensure hooks run consistently on Hub page

### DIFF
--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -51,6 +51,19 @@ export default function HubPage() {
     }
   }, [isAuthenticated, router])
 
+  useEffect(() => {
+    if (!isAuthenticated) return
+
+    const fetchPolls = async () => {
+      const res = await fetch("/api/polls")
+      if (res.ok) {
+        const data = await res.json()
+        setVotingPolls(data)
+      }
+    }
+    fetchPolls()
+  }, [isAuthenticated])
+
   if (!isAuthenticated) {
     return null
   }
@@ -80,17 +93,6 @@ export default function HubPage() {
   const handleFileDelete = (fileId: string) => {
     setSharedFiles((prev) => prev.filter((file) => file.id !== fileId))
   }
-
-  useEffect(() => {
-    const fetchPolls = async () => {
-      const res = await fetch("/api/polls")
-      if (res.ok) {
-        const data = await res.json()
-        setVotingPolls(data)
-      }
-    }
-    fetchPolls()
-  }, [])
 
   const handleVote = async (pollId: string, optionId: string) => {
     setUserVotes((prev) => ({ ...prev, [pollId]: optionId }))


### PR DESCRIPTION
## Summary
- Consolidate useEffect hooks before the auth guard on Hub page to maintain consistent hook ordering
- Skip poll fetching effect when user isn't authenticated

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a86824d9b883278e5124a9e0294c90