### PR TITLE
fix: escape quotes for lint

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -26,7 +26,7 @@ export default function BlogPost({ params }: BlogPostPageProps) {
         <PageLayout>
           <div className="text-center space-y-4">
             <h1 className="text-4xl font-bold">Post Not Found</h1>
-            <p className="text-muted-foreground">The blog post you're looking for doesn't exist.</p>
+            <p className="text-muted-foreground">The blog post you&apos;re looking for doesn&apos;t exist.</p>
             <Link href="/blog" className="inline-flex items-center gap-2 text-primary hover:underline">
               <ArrowLeft className="w-4 h-4" />
               Back to Blog

--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -24,7 +24,7 @@ export default function CaseStudy({ params }: CaseStudyPageProps) {
         <PageLayout>
           <div className="text-center space-y-4">
             <h1 className="text-4xl font-bold">Case Study Not Found</h1>
-            <p className="text-muted-foreground">The case study you're looking for doesn't exist.</p>
+            <p className="text-muted-foreground">The case study you&apos;re looking for doesn&apos;t exist.</p>
             <Link href="/case-studies" className="inline-flex items-center gap-2 text-primary hover:underline">
               <ArrowLeft className="w-4 h-4" />
               Back to Case Studies
@@ -119,7 +119,7 @@ export default function CaseStudy({ params }: CaseStudyPageProps) {
                 <FadeInSection>
                   <div className="bg-primary/5 border border-primary/20 rounded-xl p-8">
                     <Quote className="w-8 h-8 text-primary mb-4" />
-                    <blockquote className="text-lg italic mb-4">"{study.testimonial.quote}"</blockquote>
+                    <blockquote className="text-lg italic mb-4">&quot;{study.testimonial.quote}&quot;</blockquote>
                     <div className="text-sm text-muted-foreground">
                       <p className="font-medium">{study.testimonial.author}</p>
                       <p>{study.testimonial.company}</p>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -44,7 +44,7 @@ export default function Projects() {
                 My Projects
               </h1>
               <p className="text-xl text-muted-foreground max-w-2xl mx-auto font-serif">
-                Explore the projects I've worked on and their impact on business operations and digital transformation.
+                Explore the projects I&apos;ve worked on and their impact on business operations and digital transformation.
               </p>
             </div>
           </FadeInSection>
@@ -76,7 +76,7 @@ export default function Projects() {
                     </div>
                     <h3 className="text-xl font-semibold mb-2">No projects found</h3>
                     <p className="text-muted-foreground">
-                      Try adjusting your search terms or filters to find what you're looking for.
+                      Try adjusting your search terms or filters to find what you&apos;re looking for.
                     </p>
                   </div>
                 )}
@@ -88,7 +88,7 @@ export default function Projects() {
             <div className="bg-gradient-to-r from-primary/10 to-secondary/10 rounded-2xl p-8 text-center">
               <h3 className="text-2xl font-bold mb-4">Have a Project in Mind?</h3>
               <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
-                I'm always excited to work on new challenges. Let's discuss how I can help bring your ideas to life.
+                I&apos;m always excited to work on new challenges. Let&apos;s discuss how I can help bring your ideas to life.
               </p>
               <button className="px-6 py-3 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-all duration-300 hover:scale-105 glow-effect">
                 Start a Conversation

--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -20,7 +20,7 @@ export default function Skills() {
                 Skills & Expertise
               </h1>
               <p className="text-xl text-muted-foreground max-w-2xl mx-auto font-serif">
-                Technical expertise and competencies I've developed throughout my career in software development and
+                Technical expertise and competencies I&apos;ve developed throughout my career in software development and
                 project management.
               </p>
             </div>

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -131,7 +131,7 @@ export function ContactForm() {
           <CheckCircle className="w-8 h-8 text-green-600 dark:text-green-400" />
         </div>
         <h3 className="text-xl font-semibold mb-2">Message Sent Successfully!</h3>
-        <p className="text-muted-foreground mb-6">Thank you for reaching out. I'll get back to you within 24 hours.</p>
+        <p className="text-muted-foreground mb-6">Thank you for reaching out. I&apos;ll get back to you within 24 hours.</p>
         <Button onClick={() => setIsSubmitted(false)} variant="outline">
           Send Another Message
         </Button>
@@ -227,7 +227,7 @@ export function ContactForm() {
                 <SelectItem value="25k-50k">$25,000 - $50,000</SelectItem>
                 <SelectItem value="50k-100k">$50,000 - $100,000</SelectItem>
                 <SelectItem value="over-100k">Over $100,000</SelectItem>
-                <SelectItem value="discuss">Let's discuss</SelectItem>
+                <SelectItem value="discuss">Let&apos;s discuss</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/components/TestimonialCard.tsx
+++ b/components/TestimonialCard.tsx
@@ -18,7 +18,7 @@ export default function TestimonialCard({ quote, name, role, company, avatar }: 
         </div>
       </div>
 
-      <blockquote className="text-card-foreground leading-relaxed mb-6 pt-4 italic">"{quote}"</blockquote>
+      <blockquote className="text-card-foreground leading-relaxed mb-6 pt-4 italic">&quot;{quote}&quot;</blockquote>
 
       <div className="flex items-center gap-4">
         <div className="w-12 h-12 rounded-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center overflow-hidden">


### PR DESCRIPTION
## Summary
- escape apostrophes and quotes in blog, case studies, projects, skills pages and related components
- resolve `react/no-unescaped-entities` lint errors

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a86e27a8988327a137c22f1a33d823