### PR TITLE
Fix skill progress UI and add live GitHub activity feed

### DIFF
--- a/components/CurrentlyPlaying.tsx
+++ b/components/CurrentlyPlaying.tsx
@@ -1,115 +1,29 @@
-"use client"
-
-import { useState, useEffect } from "react"
-import { Card } from "@/components/ui/card"
-import { Music, Play, Pause } from "lucide-react"
-
-interface Track {
-  name: string
-  artist: string
-  album: string
-  isPlaying: boolean
-  progress: number
-  duration: number
-}
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 
 export function CurrentlyPlaying() {
-  const [track, setTrack] = useState<Track | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    // Simulate Spotify API call with mock data
-    const mockTrack: Track = {
-      name: "Focused Flow",
-      artist: "Lo-Fi Study Beats",
-      album: "Coding Sessions",
-      isPlaying: true,
-      progress: 142,
-      duration: 240,
-    }
-
-    setTimeout(() => {
-      setTrack(mockTrack)
-      setLoading(false)
-    }, 800)
-
-    // Simulate progress updates
-    const interval = setInterval(() => {
-      setTrack((prev) => {
-        if (!prev || !prev.isPlaying) return prev
-        const newProgress = prev.progress + 1
-        return {
-          ...prev,
-          progress: newProgress > prev.duration ? 0 : newProgress,
-        }
-      })
-    }, 1000)
-
-    return () => clearInterval(interval)
-  }, [])
-
-  const formatTime = (seconds: number) => {
-    const mins = Math.floor(seconds / 60)
-    const secs = seconds % 60
-    return `${mins}:${secs.toString().padStart(2, "0")}`
-  }
-
-  if (loading) {
-    return (
-      <Card className="p-4">
-        <div className="flex items-center gap-3">
-          <div className="w-12 h-12 bg-muted rounded animate-pulse"></div>
-          <div className="flex-1">
-            <div className="h-4 bg-muted rounded w-3/4 mb-2 animate-pulse"></div>
-            <div className="h-3 bg-muted rounded w-1/2 animate-pulse"></div>
-          </div>
-        </div>
-      </Card>
-    )
-  }
-
-  if (!track) {
-    return (
-      <Card className="p-4">
-        <div className="flex items-center gap-3 text-muted-foreground">
-          <Music className="w-5 h-5" />
-          <span className="text-sm">Not currently playing</span>
-        </div>
-      </Card>
-    )
-  }
-
   return (
-    <Card className="p-4">
-      <div className="flex items-center gap-3 mb-3">
-        <div className="w-12 h-12 bg-gradient-to-br from-primary/20 to-secondary/20 rounded flex items-center justify-center">
-          <Music className="w-6 h-6 text-primary" />
-        </div>
-        <div className="flex-1 min-w-0">
-          <h4 className="font-medium text-sm truncate">{track.name}</h4>
-          <p className="text-xs text-muted-foreground truncate">{track.artist}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          {track.isPlaying ? (
-            <Pause className="w-4 h-4 text-primary" />
-          ) : (
-            <Play className="w-4 h-4 text-muted-foreground" />
-          )}
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <div className="w-full bg-muted rounded-full h-1">
-          <div
-            className="bg-primary h-1 rounded-full transition-all duration-1000 ease-linear"
-            style={{ width: `${(track.progress / track.duration) * 100}%` }}
-          />
-        </div>
-        <div className="flex justify-between text-xs text-muted-foreground">
-          <span>{formatTime(track.progress)}</span>
-          <span>{formatTime(track.duration)}</span>
-        </div>
-      </div>
+    <Card className="overflow-hidden">
+      <CardHeader className="pb-0">
+        <CardTitle className="text-base">Demon Slayer × Spotify Playlist</CardTitle>
+        <CardDescription>
+          Stream the soundtrack that&apos;s fueling my current focus sessions.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="px-0 pb-6">
+        <iframe
+          title="Demon Slayer × Spotify Playlist"
+          src="https://open.spotify.com/embed/playlist/3JsgfcruuxFw2jqZYsVPGN?utm_source=generator"
+          width="100%"
+          height="352"
+          frameBorder="0"
+          allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+          loading="lazy"
+          allowFullScreen
+          className="mt-4 w-full"
+        >
+          Your browser does not support iframes.
+        </iframe>
+      </CardContent>
     </Card>
   )
 }

--- a/components/CurrentlyPlaying.tsx
+++ b/components/CurrentlyPlaying.tsx
@@ -2,14 +2,14 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 export function CurrentlyPlaying() {
   return (
-    <Card className="overflow-hidden">
-      <CardHeader className="pb-0">
+    <Card className="overflow-hidden border-none bg-transparent p-0 shadow-none">
+      <CardHeader className="px-0 pb-4">
         <CardTitle className="text-base">Demon Slayer × Spotify Playlist</CardTitle>
         <CardDescription>
           Stream the soundtrack that&apos;s fueling my current focus sessions.
         </CardDescription>
       </CardHeader>
-      <CardContent className="px-0 pb-6">
+      <CardContent className="px-0 pb-0">
         <iframe
           title="Demon Slayer × Spotify Playlist"
           src="https://open.spotify.com/embed/playlist/3JsgfcruuxFw2jqZYsVPGN?utm_source=generator"
@@ -19,7 +19,7 @@ export function CurrentlyPlaying() {
           allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
           loading="lazy"
           allowFullScreen
-          className="mt-4 w-full"
+          className="mt-4 w-full rounded-xl"
         >
           Your browser does not support iframes.
         </iframe>

--- a/components/CurrentlyPlaying.tsx
+++ b/components/CurrentlyPlaying.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 export function CurrentlyPlaying() {
   return (
-    <Card className="overflow-hidden border-none bg-transparent gap-4 pb-0 shadow-none">
+    <Card className="overflow-hidden gap-4 pb-0">
       <CardHeader className="pb-0">
         <CardTitle className="text-base">Demon Slayer × Spotify Playlist</CardTitle>
         <CardDescription>

--- a/components/CurrentlyPlaying.tsx
+++ b/components/CurrentlyPlaying.tsx
@@ -2,8 +2,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 export function CurrentlyPlaying() {
   return (
-    <Card className="overflow-hidden border-none bg-transparent p-0 shadow-none">
-      <CardHeader className="px-0 pb-4">
+    <Card className="overflow-hidden border-none bg-transparent gap-4 pb-0 shadow-none">
+      <CardHeader className="pb-0">
         <CardTitle className="text-base">Demon Slayer × Spotify Playlist</CardTitle>
         <CardDescription>
           Stream the soundtrack that&apos;s fueling my current focus sessions.
@@ -19,7 +19,7 @@ export function CurrentlyPlaying() {
           allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
           loading="lazy"
           allowFullScreen
-          className="mt-4 w-full rounded-xl"
+          className="w-full rounded-xl"
         >
           Your browser does not support iframes.
         </iframe>

--- a/components/GitHubActivity.tsx
+++ b/components/GitHubActivity.tsx
@@ -1,70 +1,356 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { Card } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { GitBranch, Star, GitCommit } from "lucide-react"
 
-interface GitHubRepo {
-  name: string
-  description: string
-  language: string
-  stars: number
-  lastCommit: string
+import { Badge } from "@/components/ui/badge"
+import { Card } from "@/components/ui/card"
+import { AlertCircle, GitBranch, GitCommit, GitFork, GitPullRequest, Star } from "lucide-react"
+
+const GITHUB_USERNAME = "sxwxbxr"
+const EVENTS_ENDPOINT = `https://api.github.com/users/${GITHUB_USERNAME}/events/public`
+
+type ActivityType = "push" | "pull_request" | "create" | "star" | "fork" | "issue" | "release" | "other"
+
+interface GitHubEvent {
+  id: string
+  type: string
+  repo: {
+    name: string
+    url: string
+  }
+  created_at: string
+  payload: Record<string, unknown>
+}
+
+interface ActivityItem {
+  id: string
+  title: string
+  description?: string
   url: string
+  repoName: string
+  repoUrl: string
+  timestamp: string
+  type: ActivityType
+}
+
+const ACTIVITY_TYPE_LABELS: Record<ActivityType, string> = {
+  push: "Push",
+  pull_request: "Pull Request",
+  create: "Create",
+  star: "Star",
+  fork: "Fork",
+  issue: "Issue",
+  release: "Release",
+  other: "Activity",
+}
+
+type PushEventPayload = {
+  commits?: Array<{
+    message?: string
+    url?: string
+  }>
+}
+
+type PullRequestEventPayload = {
+  action?: string
+  pull_request?: {
+    number?: number
+    title?: string
+    html_url?: string
+  }
+}
+
+type CreateEventPayload = {
+  ref_type?: string
+  ref?: string
+}
+
+type ForkEventPayload = {
+  forkee?: {
+    html_url?: string
+  }
+}
+
+type IssuesEventPayload = {
+  action?: string
+  issue?: {
+    number?: number
+    title?: string
+    html_url?: string
+  }
+}
+
+type ReleaseEventPayload = {
+  action?: string
+  release?: {
+    tag_name?: string
+    name?: string
+    html_url?: string
+  }
+}
+
+const getActivityIcon = (type: ActivityType) => {
+  switch (type) {
+    case "push":
+      return <GitCommit className="h-3.5 w-3.5 text-primary" />
+    case "pull_request":
+      return <GitPullRequest className="h-3.5 w-3.5 text-primary" />
+    case "star":
+      return <Star className="h-3.5 w-3.5 text-primary" />
+    case "fork":
+      return <GitFork className="h-3.5 w-3.5 text-primary" />
+    default:
+      return <GitBranch className="h-3.5 w-3.5 text-primary" />
+  }
+}
+
+const capitalize = (value?: string) => {
+  if (!value) return ""
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+const toCommitUrl = (apiUrl?: string) => {
+  if (!apiUrl) return undefined
+  return apiUrl.replace("api.github.com/repos", "github.com").replace("/commits/", "/commit/")
+}
+
+const formatRelativeTime = (dateString: string) => {
+  const date = new Date(dateString)
+  if (Number.isNaN(date.getTime())) return ""
+
+  const seconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000))
+  if (seconds < 60) return `${seconds}s ago`
+
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+
+  const weeks = Math.floor(days / 7)
+  if (weeks < 5) return `${weeks}w ago`
+
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months}mo ago`
+
+  const years = Math.floor(days / 365)
+  return `${years}y ago`
+}
+
+const mapEventToActivity = (event: GitHubEvent): ActivityItem => {
+  const repoName = event.repo?.name ?? ""
+  const repoUrl = event.repo?.name ? `https://github.com/${event.repo.name}` : "https://github.com"
+  const payload = event.payload ?? {}
+
+  switch (event.type) {
+    case "PushEvent": {
+      const pushPayload = payload as PushEventPayload
+      const commits = Array.isArray(pushPayload.commits) ? pushPayload.commits ?? [] : []
+      const commitCount = commits.length
+      const commitWord = commitCount === 1 ? "commit" : "commits"
+      const commitMessage = commits[0]?.message?.split("\n")[0]
+      const commitUrl = toCommitUrl(commits[0]?.url) ?? repoUrl
+
+      return {
+        id: event.id,
+        type: "push",
+        title: commitCount
+          ? `Pushed ${commitCount} ${commitWord} to ${repoName}`
+          : `Pushed updates to ${repoName}`,
+        description: commitMessage,
+        url: commitUrl,
+        repoName,
+        repoUrl,
+        timestamp: event.created_at,
+      }
+    }
+    case "PullRequestEvent": {
+      const pullRequestPayload = payload as PullRequestEventPayload
+      const action = pullRequestPayload.action ?? "updated"
+      const pullRequest = pullRequestPayload.pull_request
+      const prNumber = pullRequest?.number
+
+      return {
+        id: event.id,
+        type: "pull_request",
+        title: `${capitalize(action)} pull request${prNumber ? ` #${prNumber}` : ""} in ${repoName}`,
+        description: pullRequest?.title ?? undefined,
+        url: pullRequest?.html_url ?? repoUrl,
+        repoName,
+        repoUrl,
+        timestamp: event.created_at,
+      }
+    }
+    case "CreateEvent": {
+      const createPayload = payload as CreateEventPayload
+      const refType = createPayload.ref_type
+      const ref = createPayload.ref
+
+      let title = `Created ${refType ?? "content"}`
+      if (refType === "repository") {
+        title = `Created repository ${repoName}`
+      } else if (refType === "branch" && ref) {
+        title = `Created branch ${ref} in ${repoName}`
+      } else if (refType === "tag" && ref) {
+        title = `Created tag ${ref} in ${repoName}`
+      }
+
+      return {
+        id: event.id,
+        type: "create",
+        title,
+        repoName,
+        repoUrl,
+        url: repoUrl,
+        timestamp: event.created_at,
+      }
+    }
+    case "WatchEvent": {
+      return {
+        id: event.id,
+        type: "star",
+        title: `Starred ${repoName}`,
+        repoName,
+        repoUrl,
+        url: repoUrl,
+        timestamp: event.created_at,
+      }
+    }
+    case "ForkEvent": {
+      const forkPayload = payload as ForkEventPayload
+      const forkee = forkPayload.forkee
+      return {
+        id: event.id,
+        type: "fork",
+        title: `Forked ${repoName}`,
+        repoName,
+        repoUrl,
+        url: forkee?.html_url ?? repoUrl,
+        timestamp: event.created_at,
+      }
+    }
+    case "IssuesEvent": {
+      const issuesPayload = payload as IssuesEventPayload
+      const action = issuesPayload.action ?? "updated"
+      const issue = issuesPayload.issue
+      const issueNumber = issue?.number
+
+      return {
+        id: event.id,
+        type: "issue",
+        title: `${capitalize(action)} issue${issueNumber ? ` #${issueNumber}` : ""} in ${repoName}`,
+        description: issue?.title ?? undefined,
+        url: issue?.html_url ?? repoUrl,
+        repoName,
+        repoUrl,
+        timestamp: event.created_at,
+      }
+    }
+    case "ReleaseEvent": {
+      const releasePayload = payload as ReleaseEventPayload
+      const action = releasePayload.action ?? "published"
+      const release = releasePayload.release
+      const tagName = release?.tag_name
+
+      return {
+        id: event.id,
+        type: "release",
+        title: `${capitalize(action)} release${tagName ? ` ${tagName}` : ""} in ${repoName}`,
+        description: release?.name ?? undefined,
+        url: release?.html_url ?? repoUrl,
+        repoName,
+        repoUrl,
+        timestamp: event.created_at,
+      }
+    }
+    default:
+      return {
+        id: event.id,
+        type: "other",
+        title: `${event.type.replace(/Event$/, "")} activity in ${repoName}`,
+        repoName,
+        repoUrl,
+        url: repoUrl,
+        timestamp: event.created_at,
+      }
+  }
 }
 
 export function GitHubActivity() {
-  const [repos, setRepos] = useState<GitHubRepo[]>([])
+  const [activity, setActivity] = useState<ActivityItem[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    // Simulate GitHub API call with mock data
-    const mockRepos: GitHubRepo[] = [
-      {
-        name: "automation-workflows",
-        description: "Custom automation workflow templates for business processes",
-        language: "C#",
-        stars: 24,
-        lastCommit: "2 days ago",
-        url: "#",
-      },
-      {
-        name: "medical-data-sync",
-        description: "Secure medical data synchronization platform",
-        language: "TypeScript",
-        stars: 18,
-        lastCommit: "5 days ago",
-        url: "#",
-      },
-      {
-        name: "test-automation-framework",
-        description: "Comprehensive testing automation templates",
-        language: "C#",
-        stars: 31,
-        lastCommit: "1 week ago",
-        url: "#",
-      },
-    ]
+    const controller = new AbortController()
 
-    setTimeout(() => {
-      setRepos(mockRepos)
-      setLoading(false)
-    }, 1000)
+    const fetchActivity = async () => {
+      try {
+        const response = await fetch(EVENTS_ENDPOINT, {
+          headers: {
+            Accept: "application/vnd.github+json",
+          },
+          cache: "no-store",
+          signal: controller.signal,
+        })
+
+        if (!response.ok) {
+          if (response.status === 403) {
+            throw new Error("GitHub rate limit reached. Please try again soon.")
+          }
+          if (response.status === 404) {
+            throw new Error("GitHub profile not found.")
+          }
+          throw new Error("Unable to load GitHub activity.")
+        }
+
+        const data = (await response.json()) as unknown
+        const events = Array.isArray(data) ? (data as GitHubEvent[]) : []
+        const normalized = events
+          .map((event) => mapEventToActivity(event))
+          .filter((item): item is ActivityItem => Boolean(item))
+          .slice(0, 3)
+
+        if (!controller.signal.aborted) {
+          setActivity(normalized)
+          setError(null)
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          return
+        }
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : "Unable to load GitHub activity.")
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchActivity()
+
+    return () => {
+      controller.abort()
+    }
   }, [])
 
   if (loading) {
     return (
       <Card className="p-6">
-        <div className="flex items-center gap-2 mb-4">
-          <GitBranch className="w-5 h-5 text-primary" />
+        <div className="mb-4 flex items-center gap-2">
+          <GitBranch className="h-5 w-5 text-primary" />
           <h3 className="font-semibold">Recent GitHub Activity</h3>
         </div>
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
             <div key={i} className="animate-pulse">
-              <div className="h-4 bg-muted rounded w-3/4 mb-2"></div>
-              <div className="h-3 bg-muted rounded w-1/2"></div>
+              <div className="mb-2 h-4 w-3/4 rounded bg-muted" />
+              <div className="h-3 w-1/2 rounded bg-muted" />
             </div>
           ))}
         </div>
@@ -74,33 +360,88 @@ export function GitHubActivity() {
 
   return (
     <Card className="p-6">
-      <div className="flex items-center gap-2 mb-4">
-        <GitBranch className="w-5 h-5 text-primary" />
+      <div className="mb-4 flex items-center gap-2">
+        <GitBranch className="h-5 w-5 text-primary" />
         <h3 className="font-semibold">Recent GitHub Activity</h3>
       </div>
-      <div className="space-y-4">
-        {repos.map((repo) => (
-          <div key={repo.name} className="border-l-2 border-primary/20 pl-4 hover:border-primary/40 transition-colors">
-            <div className="flex items-start justify-between mb-2">
-              <h4 className="font-medium text-sm hover:text-primary transition-colors cursor-pointer">{repo.name}</h4>
-              <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                <Star className="w-3 h-3" />
-                {repo.stars}
-              </div>
-            </div>
-            <p className="text-xs text-muted-foreground mb-2 line-clamp-2">{repo.description}</p>
-            <div className="flex items-center gap-3 text-xs text-muted-foreground">
-              <Badge variant="secondary" className="text-xs">
-                {repo.language}
-              </Badge>
-              <div className="flex items-center gap-1">
-                <GitCommit className="w-3 h-3" />
-                {repo.lastCommit}
-              </div>
+
+      {error ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-muted-foreground">
+          <div className="flex items-start gap-2">
+            <AlertCircle className="h-4 w-4 text-destructive" />
+            <div className="space-y-2">
+              <p>{error}</p>
+              <a
+                href={`https://github.com/${GITHUB_USERNAME}`}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center text-xs font-medium text-primary underline-offset-4 hover:underline"
+              >
+                Visit GitHub profile
+              </a>
             </div>
           </div>
-        ))}
-      </div>
+        </div>
+      ) : activity.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No public activity found recently. Check out my
+          <a
+            href={`https://github.com/${GITHUB_USERNAME}`}
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 inline-flex items-center text-primary underline-offset-4 hover:underline"
+          >
+            GitHub profile
+          </a>
+          for more.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {activity.map((item) => (
+            <div
+              key={item.id}
+              className="border-l-2 border-primary/20 pl-4 transition-colors hover:border-primary/40"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex flex-1 items-start gap-3">
+                  <div className="mt-0.5 rounded-full bg-primary/10 p-1">
+                    {getActivityIcon(item.type)}
+                  </div>
+                  <div className="space-y-1">
+                    <a
+                      href={item.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-sm font-medium text-card-foreground transition-colors hover:text-primary"
+                    >
+                      {item.title}
+                    </a>
+                    {item.description ? (
+                      <p className="text-xs text-muted-foreground line-clamp-2">{item.description}</p>
+                    ) : null}
+                  </div>
+                </div>
+                <span className="whitespace-nowrap text-xs text-muted-foreground">
+                  {formatRelativeTime(item.timestamp)}
+                </span>
+              </div>
+              <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                <Badge variant="secondary" className="text-xs">
+                  {ACTIVITY_TYPE_LABELS[item.type]}
+                </Badge>
+                <a
+                  href={item.repoUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="transition-colors hover:text-primary"
+                >
+                  {item.repoName}
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </Card>
   )
 }

--- a/components/SkillProgress.tsx
+++ b/components/SkillProgress.tsx
@@ -11,12 +11,13 @@ interface Skill {
 }
 
 const skills: Skill[] = [
-  { name: "C#/.NET", level: 45, category: "Backend" },
-  { name: "TypeScript", level: 35, category: "Frontend" },
-  { name: "SQL Server", level: 30, category: "Database" },
+  { name: "C#/.NET", level: 40, category: "Backend" },
+  { name: "TypeScript", level: 45, category: "Frontend" },
+  { name: "SQL Server", level: 25, category: "Database" },
   { name: "Azure", level: 10, category: "Cloud" },
-  { name: "React", level: 50, category: "Frontend" },
-  { name: "Docker", level: 25, category: "DevOps" },
+  { name: "React", level: 45, category: "Frontend" },
+  { name: "Docker", level: 10, category: "DevOps" },
+  { name: "Next.JS", level: 45, category: "Frontend" },
 ]
 
 export function SkillProgress() {

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -22,8 +22,8 @@ const Progress = React.forwardRef<
       {...props}
     >
       <ProgressPrimitive.Indicator
-        className="h-full bg-gradient-to-r from-primary to-secondary transition-[width] duration-300 ease-out"
-        style={{ width: `${clampedValue}%` }}
+        className="h-full origin-left rounded-full bg-gradient-to-r from-primary to-secondary transition-transform duration-300 ease-out"
+        style={{ transform: `scaleX(${clampedValue / 100})`, transformOrigin: "left" }}
       />
     </ProgressPrimitive.Root>
   )

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -9,7 +9,10 @@ const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
 >(({ className, value = 0, ...props }, ref) => {
-  const clampedValue = Math.min(100, Math.max(0, value))
+  const numericValue = Number(value)
+  const clampedValue = Number.isFinite(numericValue)
+    ? Math.min(100, Math.max(0, numericValue))
+    : 0
 
   return (
     <ProgressPrimitive.Root
@@ -19,8 +22,8 @@ const Progress = React.forwardRef<
       {...props}
     >
       <ProgressPrimitive.Indicator
-        className="h-full bg-gradient-to-r from-primary to-secondary transition-all"
-        style={{ width: `${clampedValue}%` }}
+        className="h-full w-full bg-gradient-to-r from-primary to-secondary transition-transform duration-300 ease-out"
+        style={{ transform: `translateX(-${100 - clampedValue}%)` }}
       />
     </ProgressPrimitive.Root>
   )

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -18,11 +18,11 @@ const Progress = React.forwardRef<
     <ProgressPrimitive.Root
       ref={ref}
       value={clampedValue}
-      className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
+      className={cn("relative h-4 w-full overflow-hidden rounded-full bg-muted", className)}
       {...props}
     >
       <ProgressPrimitive.Indicator
-        className="h-full origin-left rounded-full bg-gradient-to-r from-primary to-secondary transition-transform duration-300 ease-out"
+        className="h-full origin-left rounded-full bg-gradient-to-r from-primary via-primary/80 to-primary/60 transition-transform duration-300 ease-out"
         style={{ transform: `scaleX(${clampedValue / 100})`, transformOrigin: "left" }}
       />
     </ProgressPrimitive.Root>

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -8,18 +8,23 @@ import { cn } from "@/lib/utils"
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-gradient-to-r from-primary to-secondary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-))
+>(({ className, value = 0, ...props }, ref) => {
+  const clampedValue = Math.min(100, Math.max(0, value))
+
+  return (
+    <ProgressPrimitive.Root
+      ref={ref}
+      value={clampedValue}
+      className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        className="h-full bg-gradient-to-r from-primary to-secondary transition-all"
+        style={{ width: `${clampedValue}%` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+})
 Progress.displayName = ProgressPrimitive.Root.displayName
 
 export { Progress }

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -22,8 +22,8 @@ const Progress = React.forwardRef<
       {...props}
     >
       <ProgressPrimitive.Indicator
-        className="h-full w-full bg-gradient-to-r from-primary to-secondary transition-transform duration-300 ease-out"
-        style={{ transform: `translateX(-${100 - clampedValue}%)` }}
+        className="h-full bg-gradient-to-r from-primary to-secondary transition-[width] duration-300 ease-out"
+        style={{ width: `${clampedValue}%` }}
       />
     </ProgressPrimitive.Root>
   )


### PR DESCRIPTION
## Summary
- clamp and animate the progress indicator width so technical skill bars reflect their configured percentages
- replace the placeholder GitHub activity card with live data from the GitHub events API, including type-specific formatting and graceful fallbacks

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2931ab6a88327a7508d102f6138c1