### PR TITLE
Enhance homepage and add services coverage

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -88,7 +88,7 @@ export default function About() {
                       <span className="text-sm font-medium">GitHub</span>
                     </a>
                     <a
-                      href="https://linkedin.com/placeholder"
+                      href="https://ch.linkedin.com/in/seya-weber-06a592256"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="flex items-center justify-center gap-2 p-3 border border-border rounded-lg hover:bg-card transition-colors"

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -128,7 +128,7 @@ export default function Contact() {
                         </InteractiveCard>
                         <InteractiveCard>
                           <a
-                            href="https://linkedin.com/placeholder"
+                            href="https://ch.linkedin.com/in/seya-weber-06a592256"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="flex items-center justify-center gap-2 p-3 bg-card border border-border rounded-lg hover:bg-primary hover:text-primary-foreground transition-all duration-300 hover:scale-105"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { ScrollProgress } from "@/components/ScrollProgress"
 import { Analytics } from "@/components/Analytics"
 import { JsonLd } from "@/components/JsonLd"
 import { Suspense } from "react"
+import { Footer } from "@/components/Footer"
 
 const geist = Geist({
   subsets: ["latin"],
@@ -154,7 +155,10 @@ export default function RootLayout({
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <ScrollProgress />
             <Analytics />
-            {children}
+            <div className="flex min-h-screen flex-col">
+              <div className="flex-1">{children}</div>
+              <Footer />
+            </div>
           </ThemeProvider>
         </Suspense>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,29 @@ import FadeInSection from "../components/FadeInSection"
 import { ParticleBackground } from "../components/ParticleBackground"
 import { AnimatedCounter } from "../components/AnimatedCounter"
 import { InteractiveCard } from "../components/InteractiveCard"
-import { ArrowDown, MapPin, ArrowRight, Users, Award, Calendar } from "lucide-react"
+import { projects, blogPosts, caseStudies } from "../src/config"
+import { ArrowDown, MapPin, ArrowRight, Users, Award, Calendar, Quote } from "lucide-react"
+
+const featuredProjects = projects.slice(0, 3)
+const featuredTestimonials = caseStudies.filter((study) => study.testimonial).slice(0, 2)
+const latestWriting = blogPosts.slice(0, 2)
+const servicePreview = [
+  {
+    title: "Digital transformation leadership",
+    description:
+      "Fractional leadership for complex software migrations, workflow automation, and cross-team programs with measurable outcomes.",
+  },
+  {
+    title: "Product & delivery coaching",
+    description:
+      "Hands-on support to align discovery, delivery, and stakeholder communication so your roadmap ships on time and on budget.",
+  },
+  {
+    title: "Technical implementation",
+    description:
+      "Execution for .NET, C#, and automation initiatives—from proof of concept to production with documentation and training."
+  },
+]
 
 export default function Home() {
   return (
@@ -121,6 +143,176 @@ export default function Home() {
                   <ArrowRight className="w-5 h-5 text-primary group-hover:translate-x-2 transition-transform duration-300" />
                 </Link>
               </InteractiveCard>
+            </div>
+          </FadeInSection>
+        </div>
+      </section>
+
+      <section className="py-24 px-4 bg-card/40">
+        <div className="max-w-6xl mx-auto space-y-12">
+          <FadeInSection>
+            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div>
+                <h2 className="text-3xl md:text-4xl font-bold">Featured Projects</h2>
+                <p className="text-muted-foreground max-w-2xl">
+                  A snapshot of multidisciplinary engagements that span software delivery, automation, and operations.
+                </p>
+              </div>
+              <Link
+                href="/projects"
+                className="inline-flex items-center gap-2 text-primary font-medium hover:gap-3 transition-all"
+              >
+                Explore all projects
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+          </FadeInSection>
+
+          <FadeInSection>
+            <div className="grid gap-6 md:grid-cols-3">
+              {featuredProjects.map((project) => (
+                <InteractiveCard key={project.slug}>
+                  <Link
+                    href={`/projects/${project.slug}`}
+                    className="group flex h-full flex-col rounded-xl border border-border bg-card p-6 transition-all duration-300 hover:-translate-y-2 hover:shadow-xl"
+                  >
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      {project.tags.slice(0, 2).map((tag) => (
+                        <span key={tag} className="rounded-full bg-primary/10 px-3 py-1 text-primary">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                    <h3 className="mt-6 text-2xl font-semibold leading-snug group-hover:text-primary transition-colors">
+                      {project.title}
+                    </h3>
+                    <p className="mt-4 text-muted-foreground leading-relaxed">{project.shortDescription}</p>
+                    <div className="mt-auto flex items-center gap-2 pt-6 text-sm font-medium text-primary">
+                      View case details
+                      <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                    </div>
+                  </Link>
+                </InteractiveCard>
+              ))}
+            </div>
+          </FadeInSection>
+        </div>
+      </section>
+
+      <section className="py-24 px-4">
+        <div className="max-w-6xl mx-auto space-y-12">
+          <FadeInSection>
+            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div>
+                <h2 className="text-3xl md:text-4xl font-bold">Services at a Glance</h2>
+                <p className="text-muted-foreground max-w-2xl">
+                  Partner with me for strategy, delivery, and implementation support tailored to your product or transformation initiative.
+                </p>
+              </div>
+              <Link
+                href="/services"
+                className="inline-flex items-center gap-2 text-primary font-medium hover:gap-3 transition-all"
+              >
+                View full services
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+          </FadeInSection>
+
+          <FadeInSection>
+            <div className="grid gap-6 md:grid-cols-3">
+              {servicePreview.map((service) => (
+                <InteractiveCard key={service.title}>
+                  <div className="h-full rounded-xl border border-border bg-card p-6">
+                    <h3 className="text-xl font-semibold">{service.title}</h3>
+                    <p className="mt-4 text-muted-foreground leading-relaxed">{service.description}</p>
+                  </div>
+                </InteractiveCard>
+              ))}
+            </div>
+          </FadeInSection>
+        </div>
+      </section>
+
+      <section className="py-24 px-4 bg-muted/40">
+        <div className="max-w-6xl mx-auto space-y-12">
+          <FadeInSection>
+            <h2 className="text-3xl md:text-4xl font-bold text-center">What partners say</h2>
+            <p className="text-muted-foreground text-center max-w-3xl mx-auto">
+              Real feedback from engagements across healthcare, finance, and residential projects.
+            </p>
+          </FadeInSection>
+
+          <FadeInSection>
+            <div className="grid gap-6 md:grid-cols-2">
+              {featuredTestimonials.map((testimonial) => (
+                <InteractiveCard key={testimonial.slug}>
+                  <div className="flex h-full flex-col rounded-xl border border-border bg-card p-8">
+                    <Quote className="h-10 w-10 text-primary" aria-hidden="true" />
+                    <blockquote className="mt-6 flex-1 text-lg italic leading-relaxed">“{testimonial.testimonial?.quote}”</blockquote>
+                    <div className="mt-6 text-sm text-muted-foreground">
+                      <p className="font-semibold text-foreground">{testimonial.testimonial?.author}</p>
+                      <p>{testimonial.testimonial?.company}</p>
+                    </div>
+                    <Link
+                      href={`/case-studies/${testimonial.slug}`}
+                      className="mt-6 inline-flex items-center gap-2 text-primary font-medium hover:gap-3 transition-all"
+                    >
+                      Read the full story
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  </div>
+                </InteractiveCard>
+              ))}
+            </div>
+          </FadeInSection>
+        </div>
+      </section>
+
+      <section className="py-24 px-4">
+        <div className="max-w-6xl mx-auto space-y-12">
+          <FadeInSection>
+            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div>
+                <h2 className="text-3xl md:text-4xl font-bold">Latest writing</h2>
+                <p className="text-muted-foreground max-w-2xl">
+                  Essays and notes on moving complex initiatives from idea to production without losing momentum.
+                </p>
+              </div>
+              <Link
+                href="/blog"
+                className="inline-flex items-center gap-2 text-primary font-medium hover:gap-3 transition-all"
+              >
+                Visit the blog
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+          </FadeInSection>
+
+          <FadeInSection>
+            <div className="grid gap-6 md:grid-cols-2">
+              {latestWriting.map((post) => (
+                <InteractiveCard key={post.id}>
+                  <Link
+                    href={`/blog/${post.id}`}
+                    className="group flex h-full flex-col rounded-xl border border-border bg-card p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+                  >
+                    <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                      <span>{new Date(post.publishedAt).toLocaleDateString()}</span>
+                      <span>•</span>
+                      <span>{post.readTime}</span>
+                    </div>
+                    <h3 className="mt-4 text-2xl font-semibold leading-snug group-hover:text-primary transition-colors">
+                      {post.title}
+                    </h3>
+                    <p className="mt-4 flex-1 text-muted-foreground leading-relaxed">{post.excerpt}</p>
+                    <div className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-primary">
+                      Read article
+                      <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                    </div>
+                  </Link>
+                </InteractiveCard>
+              ))}
             </div>
           </FadeInSection>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,7 +50,7 @@ export default function Home() {
                 Hi, I&apos;m Seya Weber
               </h1>
               <p className="text-xl md:text-2xl text-muted-foreground max-w-2xl mx-auto leading-relaxed font-serif animate-in fade-in slide-in-from-bottom-4 duration-1000 delay-200">
-                Project Manager Software and Digitalisation in St. Gallen, Switzerland.
+                Project Manager Software and Digitalisation and Founder / Owner of Weber Development in St. Gallen, Switzerland.
               </p>
             </div>
 
@@ -87,7 +87,7 @@ export default function Home() {
             <div className="grid md:grid-cols-3 gap-8 text-center">
               <div className="space-y-2">
                 <Users className="w-8 h-8 text-primary mx-auto mb-4" />
-                <AnimatedCounter end={6} suffix="+" />
+                <AnimatedCounter end={projects.length} suffix="+" />
                 <p className="text-muted-foreground">Projects Completed</p>
               </div>
               <div className="space-y-2">

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import PageLayout from "../../components/PageLayout"
+import FadeInSection from "../../components/FadeInSection"
+import { InteractiveCard } from "../../components/InteractiveCard"
+import Link from "next/link"
+import { CheckCircle2, Workflow, Users, Lightbulb, ArrowRight } from "lucide-react"
+
+const servicePackages = [
+  {
+    title: "Delivery Leadership",
+    description:
+      "Fractional project leadership for digital transformation programs, complex migrations, and automation efforts.",
+    outcomes: [
+      "Clear scope, roadmap, and stakeholder alignment",
+      "Risk and dependency management across teams",
+      "Reporting cadences tailored to executive needs",
+    ],
+  },
+  {
+    title: "Solution Acceleration",
+    description: "Hands-on implementation to turn validated concepts into production-ready tools and workflows.",
+    outcomes: [
+      "Rapid proof-of-concept and MVP builds",
+      "Documentation and training for smooth handover",
+      "QA support and instrumentation for continuous improvement",
+    ],
+  },
+  {
+    title: "Process & Product Coaching",
+    description: "Support for teams adopting agile practices, shaping product discovery, and improving delivery rituals.",
+    outcomes: [
+      "Discovery and delivery frameworks your team can run",
+      "Templates, checklists, and playbooks for repeatability",
+      "Embedded coaching to reinforce new habits",
+    ],
+  },
+]
+
+const engagementProcess = [
+  {
+    title: "1. Alignment Workshop",
+    detail: "We map objectives, constraints, and success metrics to ensure the engagement starts with clarity.",
+  },
+  {
+    title: "2. Co-created Delivery Plan",
+    detail: "We shape the roadmap, define responsibilities, and agree on communication and reporting rhythms.",
+  },
+  {
+    title: "3. Execution & Iteration",
+    detail: "Implementation begins with visible checkpoints, demos, and data so stakeholders stay informed.",
+  },
+  {
+    title: "4. Handover & Next Steps",
+    detail: "We wrap with documentation, training, and recommendations that support long-term ownership.",
+  },
+]
+
+const engagementModels = [
+  {
+    title: "Project-based",
+    description: "Fixed-scope initiatives with defined milestones and delivery outcomes.",
+  },
+  {
+    title: "Retainer",
+    description: "Ongoing advisory and execution support for teams that want a strategic partner on call.",
+  },
+  {
+    title: "Workshops",
+    description: "Focused sessions to unblock decisions, facilitate discovery, or upskill your internal team.",
+  },
+]
+
+export default function Services() {
+  return (
+    <PageLayout
+      title="Services"
+      subtitle="Partner with me to move complex initiatives from idea to impact with the right blend of strategy and execution"
+    >
+      <section className="py-24 px-4">
+        <div className="mx-auto max-w-6xl space-y-16">
+          <FadeInSection>
+            <div className="grid gap-8 md:grid-cols-3">
+              {servicePackages.map((service) => (
+                <InteractiveCard key={service.title}>
+                  <div className="flex h-full flex-col rounded-xl border border-border bg-card p-8">
+                    <div className="flex items-center gap-3 text-primary">
+                      <Lightbulb className="h-6 w-6" aria-hidden="true" />
+                      <h3 className="text-xl font-semibold text-foreground">{service.title}</h3>
+                    </div>
+                    <p className="mt-4 text-muted-foreground leading-relaxed">{service.description}</p>
+                    <ul className="mt-6 space-y-3 text-sm text-muted-foreground">
+                      {service.outcomes.map((outcome) => (
+                        <li key={outcome} className="flex items-start gap-2">
+                          <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" aria-hidden="true" />
+                          <span>{outcome}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </InteractiveCard>
+              ))}
+            </div>
+          </FadeInSection>
+
+          <FadeInSection>
+            <div className="grid gap-8 md:grid-cols-2">
+              <InteractiveCard>
+                <div className="h-full rounded-xl border border-border bg-card p-8">
+                  <h3 className="text-2xl font-semibold">How engagements unfold</h3>
+                  <p className="mt-3 text-muted-foreground">
+                    Every partnership is structured for clarity, predictable delivery, and measurable results.
+                  </p>
+                  <ol className="mt-6 space-y-4 text-muted-foreground">
+                    {engagementProcess.map((step) => (
+                      <li key={step.title} className="rounded-lg bg-muted/40 p-4">
+                        <p className="font-semibold text-foreground">{step.title}</p>
+                        <p className="mt-2 text-sm leading-relaxed">{step.detail}</p>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              </InteractiveCard>
+
+              <InteractiveCard>
+                <div className="h-full rounded-xl border border-border bg-card p-8">
+                  <h3 className="text-2xl font-semibold">Who I work with</h3>
+                  <p className="mt-3 text-muted-foreground">
+                    Teams that need a trusted partner to navigate digital change without disrupting the day-to-day.
+                  </p>
+                  <ul className="mt-6 space-y-4 text-muted-foreground">
+                    <li className="flex items-start gap-3">
+                      <Users className="mt-1 h-5 w-5 text-primary" aria-hidden="true" />
+                      <span>Operations leaders modernising legacy workflows and tooling.</span>
+                    </li>
+                    <li className="flex items-start gap-3">
+                      <Workflow className="mt-1 h-5 w-5 text-primary" aria-hidden="true" />
+                      <span>Product teams balancing regulatory, technical, and stakeholder demands.</span>
+                    </li>
+                    <li className="flex items-start gap-3">
+                      <Lightbulb className="mt-1 h-5 w-5 text-primary" aria-hidden="true" />
+                      <span>Founders and innovators seeking a pragmatic path from concept to launch.</span>
+                    </li>
+                  </ul>
+                </div>
+              </InteractiveCard>
+            </div>
+          </FadeInSection>
+
+          <FadeInSection>
+            <div className="rounded-2xl border border-primary/30 bg-gradient-to-br from-primary/10 to-secondary/10 p-10 text-center">
+              <h3 className="text-3xl font-semibold">Let&apos;s scope your next initiative</h3>
+              <p className="mt-4 text-muted-foreground max-w-2xl mx-auto">
+                Share your goals and constraints, and I&apos;ll outline the approach, timeline, and collaboration model that gets you there.
+              </p>
+              <div className="mt-6 flex flex-wrap justify-center gap-4">
+                <Link
+                  href="/contact"
+                  className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  Start a project
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link
+                  href="mailto:hello@seyaweber.com"
+                  className="inline-flex items-center gap-2 rounded-lg border border-border px-6 py-3 font-medium transition-colors hover:bg-card"
+                >
+                  Email me directly
+                </Link>
+              </div>
+            </div>
+          </FadeInSection>
+
+          <FadeInSection>
+            <div className="grid gap-6 md:grid-cols-3">
+              {engagementModels.map((model) => (
+                <div key={model.title} className="rounded-xl border border-border bg-card p-6 text-center">
+                  <h4 className="text-lg font-semibold text-foreground">{model.title}</h4>
+                  <p className="mt-3 text-sm text-muted-foreground leading-relaxed">{model.description}</p>
+                </div>
+              ))}
+            </div>
+          </FadeInSection>
+        </div>
+      </section>
+    </PageLayout>
+  )
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -162,7 +162,7 @@ export default function Services() {
                   <ArrowRight className="h-4 w-4" />
                 </Link>
                 <Link
-                  href="mailto:hello@seyaweber.com"
+                  href="mailto:swbr@sweber.dev"
                   className="inline-flex items-center gap-2 rounded-lg border border-border px-6 py-3 font-medium transition-colors hover:bg-card"
                 >
                   Email me directly

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { Mail, MapPin, Linkedin, Github } from "lucide-react"
+import { SiGithub, SiLinkedin } from "react-icons/si"
 
 const quickLinks = [
   { name: "Projects", href: "/projects" },
@@ -12,8 +13,8 @@ const contactItems = [
   {
     icon: Mail,
     label: "Email",
-    value: "hello@seyaweber.com",
-    href: "mailto:hello@seyaweber.com",
+    value: "swbr@sweber.dev",
+    href: "mailto:swbr@sweber.dev",
   },
   {
     icon: MapPin,
@@ -24,12 +25,12 @@ const contactItems = [
 
 const socialLinks = [
   {
-    icon: Linkedin,
+    icon: SiLinkedin,
     label: "LinkedIn",
-    href: "https://linkedin.com/in/seyaweber",
+    href: "https://ch.linkedin.com/in/seya-weber-06a592256",
   },
   {
-    icon: Github,
+    icon: SiGithub,
     label: "GitHub",
     href: "https://github.com/sxwxbxr",
   },

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link"
+import { Mail, MapPin, Linkedin, Github } from "lucide-react"
+
+const quickLinks = [
+  { name: "Projects", href: "/projects" },
+  { name: "Case Studies", href: "/case-studies" },
+  { name: "Services", href: "/services" },
+  { name: "Blog", href: "/blog" },
+]
+
+const contactItems = [
+  {
+    icon: Mail,
+    label: "Email",
+    value: "hello@seyaweber.com",
+    href: "mailto:hello@seyaweber.com",
+  },
+  {
+    icon: MapPin,
+    label: "Location",
+    value: "St. Gallen, Switzerland",
+  },
+]
+
+const socialLinks = [
+  {
+    icon: Linkedin,
+    label: "LinkedIn",
+    href: "https://linkedin.com/in/seyaweber",
+  },
+  {
+    icon: Github,
+    label: "GitHub",
+    href: "https://github.com/sxwxbxr",
+  },
+]
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      <div className="max-w-6xl mx-auto px-4 py-12">
+        <div className="grid gap-12 md:grid-cols-[2fr_1fr_1fr]">
+          <div>
+            <Link
+              href="/contact"
+              className="text-2xl font-semibold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent"
+            >
+              Let&apos;s build your next project
+            </Link>
+            <p className="mt-4 text-muted-foreground max-w-md">
+              From clinical software migrations to automation and energy optimisation programs, I partner with teams to deliver
+              measurable outcomes. Reach out and let&apos;s scope what success looks like for you.
+            </p>
+            <div className="mt-6 flex flex-col gap-4">
+              {contactItems.map((item) => (
+                <div key={item.label} className="flex items-start gap-3 text-sm text-muted-foreground">
+                  <item.icon className="mt-0.5 h-4 w-4 text-primary" aria-hidden="true" />
+                  <div>
+                    <p className="font-medium text-foreground">{item.label}</p>
+                    {item.href ? (
+                  <Link href={item.href} className="hover:text-primary transition-colors">
+                    {item.value}
+                  </Link>
+                    ) : (
+                      <p>{item.value}</p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Quick Links</h3>
+            <ul className="mt-4 space-y-3 text-sm">
+              {quickLinks.map((link) => (
+                <li key={link.href}>
+                  <Link href={link.href} className="hover:text-primary transition-colors">
+                    {link.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Social</h3>
+            <ul className="mt-4 space-y-3 text-sm">
+              {socialLinks.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className="flex items-center gap-2 hover:text-primary transition-colors"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <link.icon className="h-4 w-4" aria-hidden="true" />
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="mt-12 border-t border-border pt-6 text-xs text-muted-foreground">
+          <p>
+            © {new Date().getFullYear()} Seya Weber. Built with care in Switzerland.
+          </p>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@ const navLinks = [
   { name: "About", href: "/about" },
   { name: "Experience", href: "/experience" },
   { name: "Projects", href: "/projects" },
+  { name: "Case Studies", href: "/case-studies" },
+  { name: "Services", href: "/services" },
   { name: "Blog", href: "/blog" },
   { name: "Education", href: "/education" },
   { name: "Skills", href: "/skills" },


### PR DESCRIPTION
## Summary
- add a global footer with contact, quick links, and social channels
- expand the homepage with featured projects, services preview, testimonials, and latest writing highlights
- create a dedicated services page and surface it alongside case studies in the main navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da721d83ec832793f0643ab9f206d8