### PR TITLE
Add Vercel Analytics integration

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -44,6 +44,18 @@ export default function About() {
               </div>
 
               <div className="space-y-6">
+                <div className="bg-card border border-border rounded-xl p-6">
+                  <h3 className="font-semibold text-lg mb-4">Introduce Yourself</h3>
+                  <div className="space-y-4">
+                    <div className="aspect-square w-full rounded-lg border-2 border-dashed border-muted-foreground/40 bg-muted/20 flex items-center justify-center text-muted-foreground">
+                      <span className="text-sm font-medium">Add your photo here</span>
+                    </div>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      Use this space to share a brief introduction and highlight the stories you want visitors to remember.
+                    </p>
+                  </div>
+                </div>
+
                 <div className="bg-gradient-to-br from-primary/10 to-secondary/10 border border-primary/20 rounded-xl p-6">
                   <h3 className="font-semibold text-lg mb-4">Quick Facts</h3>
                   <div className="space-y-3 text-sm">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -154,13 +154,13 @@ export default function RootLayout({
         <Suspense fallback={null}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <ScrollProgress />
-            <Analytics />
             <div className="flex min-h-screen flex-col">
               <div className="flex-1">{children}</div>
               <Footer />
             </div>
           </ThemeProvider>
         </Suspense>
+        <Analytics />
       </body>
     </html>
   )

--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -1,23 +1,7 @@
 "use client"
 
-import { useEffect } from "react"
-import { usePathname } from "next/navigation"
+import { Analytics as VercelAnalytics } from "@vercel/analytics/react"
 
 export function Analytics() {
-  const pathname = usePathname()
-
-  useEffect(() => {
-    // Track page views
-    if (typeof window !== "undefined") {
-      console.log("[v0] Page view tracked:", pathname)
-
-      // Here you would integrate with your analytics service
-      // Example: Google Analytics, Vercel Analytics, etc.
-      // gtag('config', 'GA_MEASUREMENT_ID', {
-      //   page_path: pathname,
-      // })
-    }
-  }, [pathname])
-
-  return null
+  return <VercelAnalytics />
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@radix-ui/react-toggle": "1.1.1",
         "@radix-ui/react-toggle-group": "1.1.1",
         "@radix-ui/react-tooltip": "1.1.6",
+        "@vercel/analytics": "^1.5.0",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -4976,6 +4977,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
+    "@vercel/analytics": "^1.5.0",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.1.6
         version: 1.1.6(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@vercel/analytics':
+        specifier: ^1.5.0
+        version: 1.5.0(next@15.2.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.0)
@@ -1686,6 +1689,32 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@1.5.0':
+    resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -4624,6 +4653,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vercel/analytics@1.5.0(next@15.2.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+    optionalDependencies:
+      next: 15.2.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:


### PR DESCRIPTION
## Summary
- add the `@vercel/analytics` package to enable native tracking support
- replace the placeholder analytics component with Vercel's Analytics component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e37ab6feac832797c4273d3ef2b54a