### PR TITLE
Certificates CMS with roadmap on Education page

### DIFF
--- a/app/admin/certificates/[id]/edit/page.tsx
+++ b/app/admin/certificates/[id]/edit/page.tsx
@@ -1,0 +1,328 @@
+"use client"
+
+import { useState, useEffect, use } from "react"
+import { useRouter } from "next/navigation"
+import FormField from "@/components/admin/FormField"
+
+const STATUS_OPTIONS = [
+  { value: "planned", label: "Planned" },
+  { value: "in-progress", label: "In Progress" },
+  { value: "completed", label: "Completed" },
+]
+
+export default function EditCertificatePage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = use(params)
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+  const [fetching, setFetching] = useState(true)
+  const [error, setError] = useState("")
+  const [form, setForm] = useState({
+    name: "",
+    fullTitle: "",
+    provider: "",
+    category: "",
+    status: "planned",
+    description: "",
+    credentialUrl: "",
+    credentialId: "",
+    issueDate: "",
+    expiryDate: "",
+    plannedStart: "",
+    plannedEnd: "",
+    estimatedHours: "0",
+    estimatedCost: "",
+    difficulty: "0",
+    skills: "",
+    whyPoints: "",
+    accentColor: "",
+    sortOrder: "0",
+  })
+
+  useEffect(() => {
+    fetch(`/api/admin/certificates/${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setForm({
+          name: data.name || "",
+          fullTitle: data.fullTitle || "",
+          provider: data.provider || "",
+          category: data.category || "",
+          status: data.status || "planned",
+          description: data.description || "",
+          credentialUrl: data.credentialUrl || "",
+          credentialId: data.credentialId || "",
+          issueDate: data.issueDate || "",
+          expiryDate: data.expiryDate || "",
+          plannedStart: data.plannedStart || "",
+          plannedEnd: data.plannedEnd || "",
+          estimatedHours: String(data.estimatedHours ?? 0),
+          estimatedCost: data.estimatedCost || "",
+          difficulty: String(data.difficulty ?? 0),
+          skills: (data.skills || []).join(", "),
+          whyPoints: (data.whyPoints || []).join("\n"),
+          accentColor: data.accentColor || "",
+          sortOrder: String(data.sortOrder ?? 0),
+        })
+        setFetching(false)
+      })
+      .catch(() => {
+        setError("Failed to load certificate")
+        setFetching(false)
+      })
+  }, [id])
+
+  function updateField(field: string, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError("")
+    setLoading(true)
+
+    try {
+      const res = await fetch(`/api/admin/certificates/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...form,
+          skills: form.skills
+            ? form.skills.split(",").map((t) => t.trim()).filter(Boolean)
+            : [],
+          whyPoints: form.whyPoints
+            ? form.whyPoints.split("\n").map((t) => t.trim()).filter(Boolean)
+            : [],
+          estimatedHours: parseInt(form.estimatedHours) || 0,
+          difficulty: parseInt(form.difficulty) || 0,
+          sortOrder: parseInt(form.sortOrder) || 0,
+        }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        setError(data.error || "Failed to update certificate")
+        return
+      }
+
+      router.push("/admin/certificates")
+    } catch {
+      setError("Something went wrong")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (fetching) {
+    return (
+      <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
+        Loading...
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div>
+        <h2 className="font-display text-2xl font-semibold tracking-tight">
+          Edit Certificate
+        </h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Update certificate details.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="glass rounded-xl p-6 space-y-5">
+        <FormField
+          label="Name (short)"
+          name="name"
+          value={form.name}
+          onChange={(e) => updateField("name", e.target.value)}
+          required
+        />
+        <FormField
+          label="Full Title"
+          name="fullTitle"
+          value={form.fullTitle}
+          onChange={(e) => updateField("fullTitle", e.target.value)}
+        />
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            label="Provider"
+            name="provider"
+            value={form.provider}
+            onChange={(e) => updateField("provider", e.target.value)}
+          />
+          <FormField
+            label="Category"
+            name="category"
+            value={form.category}
+            onChange={(e) => updateField("category", e.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="status" className="text-sm font-medium text-foreground">
+            Status<span className="text-destructive ml-1">*</span>
+          </label>
+          <select
+            id="status"
+            name="status"
+            value={form.status}
+            onChange={(e) => updateField("status", e.target.value)}
+            className="w-full px-4 py-2.5 bg-transparent border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <FormField
+          label="Description"
+          name="description"
+          value={form.description}
+          onChange={(e) => updateField("description", e.target.value)}
+          multiline
+          rows={5}
+        />
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            label="Credential URL"
+            name="credentialUrl"
+            value={form.credentialUrl}
+            onChange={(e) => updateField("credentialUrl", e.target.value)}
+          />
+          <FormField
+            label="Credential ID"
+            name="credentialId"
+            value={form.credentialId}
+            onChange={(e) => updateField("credentialId", e.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground font-mono uppercase tracking-wider">
+            Completed certificates
+          </p>
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              label="Issue Date"
+              name="issueDate"
+              value={form.issueDate}
+              onChange={(e) => updateField("issueDate", e.target.value)}
+              placeholder="2026-06"
+            />
+            <FormField
+              label="Expiry Date (empty = lifetime)"
+              name="expiryDate"
+              value={form.expiryDate}
+              onChange={(e) => updateField("expiryDate", e.target.value)}
+              placeholder="2029-06"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground font-mono uppercase tracking-wider">
+            Roadmap (planned / in-progress)
+          </p>
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              label="Planned Start"
+              name="plannedStart"
+              value={form.plannedStart}
+              onChange={(e) => updateField("plannedStart", e.target.value)}
+              placeholder="2026-05"
+            />
+            <FormField
+              label="Planned End"
+              name="plannedEnd"
+              value={form.plannedEnd}
+              onChange={(e) => updateField("plannedEnd", e.target.value)}
+              placeholder="2026-06"
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            <FormField
+              label="Estimated Hours"
+              name="estimatedHours"
+              type="number"
+              value={form.estimatedHours}
+              onChange={(e) => updateField("estimatedHours", e.target.value)}
+            />
+            <FormField
+              label="Estimated Cost"
+              name="estimatedCost"
+              value={form.estimatedCost}
+              onChange={(e) => updateField("estimatedCost", e.target.value)}
+            />
+            <FormField
+              label="Difficulty (0-5)"
+              name="difficulty"
+              type="number"
+              value={form.difficulty}
+              onChange={(e) => updateField("difficulty", e.target.value)}
+            />
+          </div>
+        </div>
+
+        <FormField
+          label="Skills (comma-separated)"
+          name="skills"
+          value={form.skills}
+          onChange={(e) => updateField("skills", e.target.value)}
+        />
+        <FormField
+          label="Why Points (one per line)"
+          name="whyPoints"
+          value={form.whyPoints}
+          onChange={(e) => updateField("whyPoints", e.target.value)}
+          multiline
+          rows={4}
+        />
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            label="Accent Color (hex)"
+            name="accentColor"
+            value={form.accentColor}
+            onChange={(e) => updateField("accentColor", e.target.value)}
+          />
+          <FormField
+            label="Sort Order"
+            name="sortOrder"
+            type="number"
+            value={form.sortOrder}
+            onChange={(e) => updateField("sortOrder", e.target.value)}
+          />
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={loading}
+            className="bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+          >
+            {loading ? "Saving..." : "Save Changes"}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="px-4 py-2 text-sm font-medium border border-border rounded-lg hover:bg-accent transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/app/admin/certificates/[id]/edit/page.tsx
+++ b/app/admin/certificates/[id]/edit/page.tsx
@@ -44,7 +44,10 @@ export default function EditCertificatePage({
 
   useEffect(() => {
     fetch(`/api/admin/certificates/${id}`)
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch certificate")
+        return res.json()
+      })
       .then((data) => {
         setForm({
           name: data.name || "",

--- a/app/admin/certificates/new/page.tsx
+++ b/app/admin/certificates/new/page.tsx
@@ -1,0 +1,295 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import FormField from "@/components/admin/FormField"
+
+const STATUS_OPTIONS = [
+  { value: "planned", label: "Planned" },
+  { value: "in-progress", label: "In Progress" },
+  { value: "completed", label: "Completed" },
+]
+
+export default function NewCertificatePage() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState("")
+  const [form, setForm] = useState({
+    name: "",
+    fullTitle: "",
+    provider: "",
+    category: "",
+    status: "planned",
+    description: "",
+    credentialUrl: "",
+    credentialId: "",
+    issueDate: "",
+    expiryDate: "",
+    plannedStart: "",
+    plannedEnd: "",
+    estimatedHours: "0",
+    estimatedCost: "",
+    difficulty: "0",
+    skills: "",
+    whyPoints: "",
+    accentColor: "",
+    sortOrder: "0",
+  })
+
+  function updateField(field: string, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError("")
+    setLoading(true)
+
+    try {
+      const res = await fetch("/api/admin/certificates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...form,
+          skills: form.skills
+            ? form.skills.split(",").map((t) => t.trim()).filter(Boolean)
+            : [],
+          whyPoints: form.whyPoints
+            ? form.whyPoints.split("\n").map((t) => t.trim()).filter(Boolean)
+            : [],
+          estimatedHours: parseInt(form.estimatedHours) || 0,
+          difficulty: parseInt(form.difficulty) || 0,
+          sortOrder: parseInt(form.sortOrder) || 0,
+        }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        setError(data.error || "Failed to create certificate")
+        return
+      }
+
+      router.push("/admin/certificates")
+    } catch {
+      setError("Something went wrong")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div>
+        <h2 className="font-display text-2xl font-semibold tracking-tight">
+          New Certificate
+        </h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Track a completed, in-progress, or planned certificate.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="glass rounded-xl p-6 space-y-5">
+        <FormField
+          label="Name (short)"
+          name="name"
+          value={form.name}
+          onChange={(e) => updateField("name", e.target.value)}
+          placeholder="Microsoft SC-900"
+          required
+        />
+        <FormField
+          label="Full Title"
+          name="fullTitle"
+          value={form.fullTitle}
+          onChange={(e) => updateField("fullTitle", e.target.value)}
+          placeholder="Security, Compliance, and Identity Fundamentals"
+        />
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            label="Provider"
+            name="provider"
+            value={form.provider}
+            onChange={(e) => updateField("provider", e.target.value)}
+            placeholder="Microsoft"
+          />
+          <FormField
+            label="Category"
+            name="category"
+            value={form.category}
+            onChange={(e) => updateField("category", e.target.value)}
+            placeholder="Cyber Foundation"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="status" className="text-sm font-medium text-foreground">
+            Status<span className="text-destructive ml-1">*</span>
+          </label>
+          <select
+            id="status"
+            name="status"
+            value={form.status}
+            onChange={(e) => updateField("status", e.target.value)}
+            className="w-full px-4 py-2.5 bg-transparent border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <FormField
+          label="Description"
+          name="description"
+          value={form.description}
+          onChange={(e) => updateField("description", e.target.value)}
+          placeholder="What this certificate covers, why it matters..."
+          multiline
+          rows={5}
+        />
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            label="Credential URL"
+            name="credentialUrl"
+            value={form.credentialUrl}
+            onChange={(e) => updateField("credentialUrl", e.target.value)}
+            placeholder="https://learn.microsoft.com/..."
+          />
+          <FormField
+            label="Credential ID"
+            name="credentialId"
+            value={form.credentialId}
+            onChange={(e) => updateField("credentialId", e.target.value)}
+            placeholder="ABCD1234"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground font-mono uppercase tracking-wider">
+            Completed certificates
+          </p>
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              label="Issue Date"
+              name="issueDate"
+              value={form.issueDate}
+              onChange={(e) => updateField("issueDate", e.target.value)}
+              placeholder="2026-06"
+            />
+            <FormField
+              label="Expiry Date (empty = lifetime)"
+              name="expiryDate"
+              value={form.expiryDate}
+              onChange={(e) => updateField("expiryDate", e.target.value)}
+              placeholder="2029-06"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground font-mono uppercase tracking-wider">
+            Roadmap (planned / in-progress)
+          </p>
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              label="Planned Start"
+              name="plannedStart"
+              value={form.plannedStart}
+              onChange={(e) => updateField("plannedStart", e.target.value)}
+              placeholder="2026-05"
+            />
+            <FormField
+              label="Planned End"
+              name="plannedEnd"
+              value={form.plannedEnd}
+              onChange={(e) => updateField("plannedEnd", e.target.value)}
+              placeholder="2026-06"
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            <FormField
+              label="Estimated Hours"
+              name="estimatedHours"
+              type="number"
+              value={form.estimatedHours}
+              onChange={(e) => updateField("estimatedHours", e.target.value)}
+              placeholder="35"
+            />
+            <FormField
+              label="Estimated Cost"
+              name="estimatedCost"
+              value={form.estimatedCost}
+              onChange={(e) => updateField("estimatedCost", e.target.value)}
+              placeholder="CHF 80"
+            />
+            <FormField
+              label="Difficulty (0-5)"
+              name="difficulty"
+              type="number"
+              value={form.difficulty}
+              onChange={(e) => updateField("difficulty", e.target.value)}
+              placeholder="2"
+            />
+          </div>
+        </div>
+
+        <FormField
+          label="Skills (comma-separated)"
+          name="skills"
+          value={form.skills}
+          onChange={(e) => updateField("skills", e.target.value)}
+          placeholder="Identity, Compliance, Zero Trust"
+        />
+        <FormField
+          label="Why Points (one per line)"
+          name="whyPoints"
+          value={form.whyPoints}
+          onChange={(e) => updateField("whyPoints", e.target.value)}
+          placeholder={"Schneller Erfolg · ~5 Wochen\nLifetime, kein Renewal"}
+          multiline
+          rows={4}
+        />
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            label="Accent Color (hex)"
+            name="accentColor"
+            value={form.accentColor}
+            onChange={(e) => updateField("accentColor", e.target.value)}
+            placeholder="#1f4068"
+          />
+          <FormField
+            label="Sort Order"
+            name="sortOrder"
+            type="number"
+            value={form.sortOrder}
+            onChange={(e) => updateField("sortOrder", e.target.value)}
+            placeholder="0"
+          />
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={loading}
+            className="bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+          >
+            {loading ? "Creating..." : "Create Certificate"}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="px-4 py-2 text-sm font-medium border border-border rounded-lg hover:bg-accent transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/app/admin/certificates/page.tsx
+++ b/app/admin/certificates/page.tsx
@@ -1,0 +1,53 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { db } from "@/lib/db"
+import { certificates } from "@/lib/schema"
+import { asc } from "drizzle-orm"
+import ContentTable from "@/components/admin/ContentTable"
+
+export default async function AdminCertificatesPage() {
+  const data = await db
+    .select()
+    .from(certificates)
+    .orderBy(asc(certificates.sortOrder))
+
+  const columns = [
+    { name: "Name", accessor: "name" },
+    { name: "Provider", accessor: "provider" },
+    { name: "Category", accessor: "category" },
+    { name: "Status", accessor: "status", type: "mono" as const },
+    { name: "Order", accessor: "sortOrder", type: "mono" as const },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="font-display text-2xl font-semibold tracking-tight">
+            Certificates
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            {data.length} certificate{data.length !== 1 ? "s" : ""} (completed,
+            in-progress, and planned)
+          </p>
+        </div>
+        <Link
+          href="/admin/certificates/new"
+          className="bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium hover:opacity-90 transition-opacity"
+        >
+          Add Certificate
+        </Link>
+      </div>
+
+      <div className="glass rounded-xl overflow-hidden">
+        <ContentTable
+          columns={columns}
+          data={data as unknown as Record<string, unknown>[]}
+          editPattern="/admin/certificates/{id}/edit"
+          deletePattern="/api/admin/certificates/{id}"
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,20 +2,26 @@ export const dynamic = "force-dynamic"
 
 import Link from "next/link"
 import { db } from "@/lib/db"
-import { projects, experienceEntries, blogPosts, caseStudies } from "@/lib/schema"
+import { projects, experienceEntries, blogPosts, caseStudies, certificates } from "@/lib/schema"
 import { count } from "drizzle-orm"
 import { getSession } from "@/lib/auth"
 
 export default async function AdminDashboardPage() {
   const session = await getSession()
 
-  const [[projectCount], [experienceCount], [blogCount], [caseStudyCount]] =
-    await Promise.all([
-      db.select({ value: count() }).from(projects),
-      db.select({ value: count() }).from(experienceEntries),
-      db.select({ value: count() }).from(blogPosts),
-      db.select({ value: count() }).from(caseStudies),
-    ])
+  const [
+    [projectCount],
+    [experienceCount],
+    [blogCount],
+    [caseStudyCount],
+    [certificateCount],
+  ] = await Promise.all([
+    db.select({ value: count() }).from(projects),
+    db.select({ value: count() }).from(experienceEntries),
+    db.select({ value: count() }).from(blogPosts),
+    db.select({ value: count() }).from(caseStudies),
+    db.select({ value: count() }).from(certificates),
+  ])
 
   const stats = [
     {
@@ -37,6 +43,11 @@ export default async function AdminDashboardPage() {
       label: "Case Studies",
       count: caseStudyCount.value,
       href: "/admin/case-studies",
+    },
+    {
+      label: "Certificates",
+      count: certificateCount.value,
+      href: "/admin/certificates",
     },
   ]
 
@@ -97,6 +108,12 @@ export default async function AdminDashboardPage() {
             className="bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium hover:opacity-90 transition-opacity"
           >
             New Case Study
+          </Link>
+          <Link
+            href="/admin/certificates/new"
+            className="bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium hover:opacity-90 transition-opacity"
+          >
+            New Certificate
           </Link>
         </div>
       </div>

--- a/app/api/admin/certificates/[id]/route.ts
+++ b/app/api/admin/certificates/[id]/route.ts
@@ -42,6 +42,10 @@ export async function PUT(
   const { id } = await params
   const body = await request.json()
 
+  if (!body.name) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 })
+  }
+
   const result = await db
     .update(certificates)
     .set({

--- a/app/api/admin/certificates/[id]/route.ts
+++ b/app/api/admin/certificates/[id]/route.ts
@@ -1,0 +1,92 @@
+export const dynamic = "force-dynamic"
+
+import { NextResponse } from "next/server"
+import { requireAuth } from "@/lib/auth"
+import { db } from "@/lib/db"
+import { certificates } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireAuth()
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { id } = await params
+  const result = await db
+    .select()
+    .from(certificates)
+    .where(eq(certificates.id, parseInt(id)))
+
+  if (!result[0]) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  return NextResponse.json(result[0])
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireAuth()
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { id } = await params
+  const body = await request.json()
+
+  const result = await db
+    .update(certificates)
+    .set({
+      name: body.name,
+      fullTitle: body.fullTitle,
+      provider: body.provider,
+      category: body.category,
+      status: body.status,
+      description: body.description,
+      credentialUrl: body.credentialUrl,
+      credentialId: body.credentialId,
+      issueDate: body.issueDate,
+      expiryDate: body.expiryDate,
+      plannedStart: body.plannedStart,
+      plannedEnd: body.plannedEnd,
+      estimatedHours: body.estimatedHours,
+      estimatedCost: body.estimatedCost,
+      difficulty: body.difficulty,
+      skills: body.skills,
+      whyPoints: body.whyPoints,
+      accentColor: body.accentColor,
+      sortOrder: body.sortOrder,
+    })
+    .where(eq(certificates.id, parseInt(id)))
+    .returning()
+
+  if (!result[0]) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  return NextResponse.json(result[0])
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireAuth()
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { id } = await params
+  await db.delete(certificates).where(eq(certificates.id, parseInt(id)))
+
+  return NextResponse.json({ success: true })
+}

--- a/app/api/admin/certificates/route.ts
+++ b/app/api/admin/certificates/route.ts
@@ -1,0 +1,65 @@
+export const dynamic = "force-dynamic"
+
+import { NextResponse } from "next/server"
+import { requireAuth } from "@/lib/auth"
+import { db } from "@/lib/db"
+import { certificates } from "@/lib/schema"
+import { asc } from "drizzle-orm"
+
+export async function GET() {
+  try {
+    await requireAuth()
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const data = await db
+    .select()
+    .from(certificates)
+    .orderBy(asc(certificates.sortOrder))
+  return NextResponse.json(data)
+}
+
+export async function POST(request: Request) {
+  try {
+    await requireAuth()
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const body = await request.json()
+
+  if (!body.name) {
+    return NextResponse.json(
+      { error: "name is required" },
+      { status: 400 }
+    )
+  }
+
+  const result = await db
+    .insert(certificates)
+    .values({
+      name: body.name,
+      fullTitle: body.fullTitle ?? "",
+      provider: body.provider ?? "",
+      category: body.category ?? "",
+      status: body.status ?? "planned",
+      description: body.description ?? "",
+      credentialUrl: body.credentialUrl ?? "",
+      credentialId: body.credentialId ?? "",
+      issueDate: body.issueDate ?? "",
+      expiryDate: body.expiryDate ?? "",
+      plannedStart: body.plannedStart ?? "",
+      plannedEnd: body.plannedEnd ?? "",
+      estimatedHours: body.estimatedHours ?? 0,
+      estimatedCost: body.estimatedCost ?? "",
+      difficulty: body.difficulty ?? 0,
+      skills: body.skills ?? [],
+      whyPoints: body.whyPoints ?? [],
+      accentColor: body.accentColor ?? "",
+      sortOrder: body.sortOrder ?? 0,
+    })
+    .returning()
+
+  return NextResponse.json(result[0], { status: 201 })
+}

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,7 +1,10 @@
-"use client"
+export const dynamic = "force-dynamic"
 
 import Link from "next/link"
 import PageLayout, { Section } from "../../components/PageLayout"
+import CertificateCard from "@/components/certificates/CertificateCard"
+import CertificatesRoadmap from "@/components/certificates/CertificatesRoadmap"
+import { getCertificates } from "@/lib/data"
 
 const education = [
   {
@@ -27,24 +30,41 @@ const education = [
   },
 ]
 
-export default function Education() {
+export default async function Education() {
+  const certificates = await getCertificates()
+
+  const completed = certificates.filter((c) => c.status === "completed")
+  const inProgress = certificates.filter((c) => c.status === "in-progress")
+  const planned = certificates.filter((c) => c.status === "planned")
+
+  const groups = [
+    { key: "in-progress", label: "In Progress", items: inProgress },
+    { key: "completed", label: "Completed", items: completed },
+    { key: "planned", label: "Planned", items: planned },
+  ].filter((g) => g.items.length > 0)
+
+  const hasRoadmap = certificates.some(
+    (c) => c.status !== "completed" && c.plannedStart
+  )
+
   return (
     <PageLayout
       title="Education"
-      subtitle="My academic journey in technology and engineering."
+      subtitle="My academic journey -- and the certifications mapping the road ahead."
     >
-      <section className="pb-24 md:pb-32">
+      {/* Academic background */}
+      <section className="pb-16 md:pb-20">
         <div className="max-w-[1200px] mx-auto px-6">
           <div>
             {education.map((edu, i) => (
               <Section key={edu.title} delay={i * 0.05}>
                 <div
-                  className={`py-8 ${
-                    i > 0 ? "border-t border-border" : ""
-                  }`}
+                  className={`py-8 ${i > 0 ? "border-t border-border" : ""}`}
                 >
                   <div className="flex flex-col md:flex-row md:items-start gap-2 md:gap-0 mb-3">
-                    <h3 className="font-semibold text-lg md:flex-1">{edu.title}</h3>
+                    <h3 className="font-semibold text-lg md:flex-1">
+                      {edu.title}
+                    </h3>
                     {edu.institution && (
                       <span className="text-muted-foreground text-sm md:flex-1">
                         {edu.institution}
@@ -62,17 +82,110 @@ export default function Education() {
             ))}
             <div className="border-t border-border" />
           </div>
-
-          <div className="mt-8">
-            <Link
-              href="/about"
-              className="link-underline text-primary text-sm font-medium"
-            >
-              More about me &rarr;
-            </Link>
-          </div>
         </div>
       </section>
+
+      {/* Certificates */}
+      <Section className="py-16 md:py-24 border-t border-border">
+        <div className="max-w-[1200px] mx-auto px-6">
+          <div className="grid grid-cols-1 md:grid-cols-[auto_1fr] items-baseline gap-4 md:gap-8 mb-10">
+            <span className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
+              § Certificates
+            </span>
+            <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight">
+              Credentials &amp; roadmap
+            </h2>
+          </div>
+
+          {certificates.length === 0 ? (
+            <div className="glass rounded-xl p-10 md:p-14 text-center">
+              <p className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">
+                Nothing posted yet
+              </p>
+              <h3 className="font-display text-2xl md:text-3xl font-semibold tracking-tight">
+                The shelf is empty -- for now.
+              </h3>
+              <p className="mt-4 text-muted-foreground max-w-xl mx-auto leading-relaxed">
+                The next stack of certifications around AI, security, and cloud
+                is being planned. Once the first cert is in motion it&apos;ll
+                show up here with progress and a roadmap.
+              </p>
+            </div>
+          ) : (
+            <>
+              <dl className="grid grid-cols-3 border-y border-border mb-12">
+                {[
+                  { label: "Completed", value: completed.length },
+                  { label: "In Progress", value: inProgress.length },
+                  { label: "Planned", value: planned.length },
+                ].map((stat, i) => (
+                  <div
+                    key={stat.label}
+                    className={`py-6 px-4 ${
+                      i > 0 ? "border-l border-border" : ""
+                    }`}
+                  >
+                    <dt className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                      {stat.label}
+                    </dt>
+                    <dd className="font-display text-3xl md:text-4xl font-semibold mt-2">
+                      {String(stat.value).padStart(2, "0")}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+
+              <div className="space-y-12 md:space-y-16">
+                {groups.map((group) => (
+                  <div key={group.key}>
+                    <div className="flex items-baseline justify-between gap-4 mb-6">
+                      <h3 className="font-display text-xl md:text-2xl font-semibold tracking-tight">
+                        {group.label}
+                      </h3>
+                      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                        {String(group.items.length).padStart(2, "0")}
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      {group.items.map((cert) => (
+                        <CertificateCard key={cert.id} cert={cert} />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </Section>
+
+      {/* Roadmap timeline */}
+      {hasRoadmap && (
+        <Section className="py-16 md:py-24 border-t border-border">
+          <div className="max-w-[1200px] mx-auto px-6">
+            <div className="grid grid-cols-1 md:grid-cols-[auto_1fr] items-baseline gap-4 md:gap-8 mb-10">
+              <span className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                § Roadmap
+              </span>
+              <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight">
+                What&apos;s next on the bench.
+              </h2>
+            </div>
+            <CertificatesRoadmap certs={certificates} />
+          </div>
+        </Section>
+      )}
+
+      <Section className="py-16 md:py-24 border-t border-border">
+        <div className="max-w-[1200px] mx-auto px-6">
+          <Link
+            href="/about"
+            className="link-underline text-primary text-sm font-medium"
+          >
+            More about me &rarr;
+          </Link>
+        </div>
+      </Section>
     </PageLayout>
   )
 }

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -88,14 +88,9 @@ export default async function Education() {
       {/* Certificates */}
       <Section className="py-16 md:py-24 border-t border-border">
         <div className="max-w-[1200px] mx-auto px-6">
-          <div className="grid grid-cols-1 md:grid-cols-[auto_1fr] items-baseline gap-4 md:gap-8 mb-10">
-            <span className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
-              § Certificates
-            </span>
-            <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight">
-              Credentials &amp; roadmap
-            </h2>
-          </div>
+          <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-10">
+            Credentials &amp; roadmap
+          </h2>
 
           {certificates.length === 0 ? (
             <div className="glass rounded-xl p-10 md:p-14 text-center">
@@ -163,14 +158,9 @@ export default async function Education() {
       {hasRoadmap && (
         <Section className="py-16 md:py-24 border-t border-border">
           <div className="max-w-[1200px] mx-auto px-6">
-            <div className="grid grid-cols-1 md:grid-cols-[auto_1fr] items-baseline gap-4 md:gap-8 mb-10">
-              <span className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                § Roadmap
-              </span>
-              <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight">
-                What&apos;s next on the bench.
-              </h2>
-            </div>
+            <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-10">
+              What&apos;s next on the bench.
+            </h2>
             <CertificatesRoadmap certs={certificates} />
           </div>
         </Section>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -20,7 +20,7 @@ const moreLinks = [
   { name: "Experience", href: "/experience", description: "Work history" },
   { name: "Blog", href: "/blog", description: "Thoughts and articles" },
   { name: "Skills", href: "/skills", description: "Technical expertise" },
-  { name: "Education", href: "/education", description: "Academic background" },
+  { name: "Education", href: "/education", description: "Academic background & certs" },
   {
     name: "Nxrthstack",
     href: "https://nxrthstack.sweber.dev",

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -9,6 +9,7 @@ const navItems = [
   { href: "/admin/experience", label: "Experience", icon: "briefcase" },
   { href: "/admin/blog", label: "Blog", icon: "pen" },
   { href: "/admin/case-studies", label: "Case Studies", icon: "file" },
+  { href: "/admin/certificates", label: "Certificates", icon: "badge" },
 ]
 
 const icons: Record<string, React.ReactNode> = {
@@ -35,6 +36,11 @@ const icons: Record<string, React.ReactNode> = {
   file: (
     <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+    </svg>
+  ),
+  badge: (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z" />
     </svg>
   ),
 }

--- a/components/certificates/CertificateCard.tsx
+++ b/components/certificates/CertificateCard.tsx
@@ -1,0 +1,197 @@
+import { certificates } from "@/lib/schema"
+import type { InferSelectModel } from "drizzle-orm"
+
+export type Certificate = InferSelectModel<typeof certificates>
+
+const STATUS_META: Record<
+  string,
+  { label: string; tone: string; dot: string }
+> = {
+  completed: {
+    label: "Completed",
+    tone: "bg-primary/10 text-primary border-primary/30",
+    dot: "bg-primary",
+  },
+  "in-progress": {
+    label: "In Progress",
+    tone: "bg-foreground/5 text-foreground border-foreground/20",
+    dot: "bg-foreground/80",
+  },
+  planned: {
+    label: "Planned",
+    tone: "bg-muted text-muted-foreground border-border",
+    dot: "bg-muted-foreground/60",
+  },
+}
+
+function formatMonth(value: string) {
+  if (!value) return ""
+  const [year, month] = value.split("-")
+  if (!year || !month) return value
+  const date = new Date(Number(year), Number(month) - 1, 1)
+  if (isNaN(date.getTime())) return value
+  return date.toLocaleString("en-US", { month: "short", year: "numeric" })
+}
+
+export default function CertificateCard({ cert }: { cert: Certificate }) {
+  const status = STATUS_META[cert.status] ?? STATUS_META.planned
+  const isLifetime =
+    cert.status === "completed" && Boolean(cert.issueDate) && !cert.expiryDate
+  const accent = cert.accentColor || undefined
+
+  return (
+    <article className="relative glass rounded-xl p-7 flex flex-col h-full overflow-hidden">
+      <span
+        className="absolute top-0 left-0 right-0 h-[3px]"
+        style={{ background: accent ?? "var(--primary)" }}
+        aria-hidden="true"
+      />
+
+      <header className="flex items-start justify-between gap-3 mb-4">
+        <span
+          className={`inline-flex items-center gap-2 px-2.5 py-1 rounded-full border text-[10px] font-mono uppercase tracking-[0.18em] ${status.tone}`}
+        >
+          <span
+            className={`w-1.5 h-1.5 rounded-full ${status.dot}`}
+            aria-hidden="true"
+          />
+          {status.label}
+        </span>
+        {isLifetime && (
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-primary border border-primary/30 bg-primary/5 rounded-full px-2.5 py-1">
+            ∞ Lifetime
+          </span>
+        )}
+      </header>
+
+      <h3 className="font-display text-xl md:text-2xl font-semibold tracking-tight">
+        {cert.name}
+      </h3>
+      {cert.fullTitle && (
+        <p className="mt-1 text-sm text-muted-foreground leading-snug">
+          {cert.fullTitle}
+        </p>
+      )}
+      {(cert.provider || cert.category) && (
+        <p className="mt-3 font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground">
+          {[cert.provider, cert.category].filter(Boolean).join(" · ")}
+        </p>
+      )}
+
+      {(cert.estimatedHours > 0 ||
+        cert.estimatedCost ||
+        cert.difficulty > 0 ||
+        cert.plannedStart) && (
+        <dl className="mt-5 grid grid-cols-2 sm:grid-cols-4 gap-3 py-4 border-y border-border">
+          {cert.plannedStart && (
+            <div>
+              <dt className="font-mono text-[9px] uppercase tracking-[0.18em] text-muted-foreground">
+                Window
+              </dt>
+              <dd className="font-display text-sm font-semibold mt-1">
+                {formatMonth(cert.plannedStart)}
+                {cert.plannedEnd ? ` -- ${formatMonth(cert.plannedEnd)}` : ""}
+              </dd>
+            </div>
+          )}
+          {cert.estimatedHours > 0 && (
+            <div>
+              <dt className="font-mono text-[9px] uppercase tracking-[0.18em] text-muted-foreground">
+                Hours
+              </dt>
+              <dd className="font-display text-sm font-semibold mt-1">
+                ~{cert.estimatedHours}h
+              </dd>
+            </div>
+          )}
+          {cert.estimatedCost && (
+            <div>
+              <dt className="font-mono text-[9px] uppercase tracking-[0.18em] text-muted-foreground">
+                Cost
+              </dt>
+              <dd className="font-display text-sm font-semibold mt-1">
+                {cert.estimatedCost}
+              </dd>
+            </div>
+          )}
+          {cert.difficulty > 0 && (
+            <div>
+              <dt className="font-mono text-[9px] uppercase tracking-[0.18em] text-muted-foreground">
+                Difficulty
+              </dt>
+              <dd
+                className="font-display text-sm font-semibold mt-1"
+                aria-label={`${cert.difficulty} out of 5`}
+              >
+                <span className="text-primary">
+                  {"★".repeat(cert.difficulty)}
+                </span>
+                <span className="text-muted-foreground/40">
+                  {"★".repeat(5 - cert.difficulty)}
+                </span>
+              </dd>
+            </div>
+          )}
+        </dl>
+      )}
+
+      {cert.description && (
+        <p className="mt-5 text-sm text-foreground/85 leading-relaxed">
+          {cert.description}
+        </p>
+      )}
+
+      {cert.skills.length > 0 && (
+        <ul className="mt-5 flex flex-wrap gap-1.5">
+          {cert.skills.map((skill) => (
+            <li
+              key={skill}
+              className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground border border-border rounded-full px-2.5 py-0.5"
+            >
+              {skill}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {cert.whyPoints.length > 0 && (
+        <div className="mt-5">
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground mb-2">
+            Why it matters
+          </p>
+          <ul className="space-y-1.5">
+            {cert.whyPoints.map((point) => (
+              <li
+                key={point}
+                className="relative pl-4 text-sm text-foreground/85 leading-relaxed"
+              >
+                <span
+                  className="absolute left-0 top-[0.55rem] w-2 h-px bg-primary"
+                  aria-hidden="true"
+                />
+                {point}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="mt-auto pt-6">
+        {cert.credentialUrl ? (
+          <a
+            href={cert.credentialUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="link-slide text-sm text-primary font-medium"
+          >
+            View credential &rarr;
+          </a>
+        ) : cert.issueDate ? (
+          <p className="font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground">
+            Issued {formatMonth(cert.issueDate)}
+          </p>
+        ) : null}
+      </div>
+    </article>
+  )
+}

--- a/components/certificates/CertificateCard.tsx
+++ b/components/certificates/CertificateCard.tsx
@@ -1,4 +1,5 @@
 import { certificates } from "@/lib/schema"
+import { formatMonth } from "@/lib/utils"
 import type { InferSelectModel } from "drizzle-orm"
 
 export type Certificate = InferSelectModel<typeof certificates>
@@ -22,15 +23,6 @@ const STATUS_META: Record<
     tone: "bg-muted text-muted-foreground border-border",
     dot: "bg-muted-foreground/60",
   },
-}
-
-function formatMonth(value: string) {
-  if (!value) return ""
-  const [year, month] = value.split("-")
-  if (!year || !month) return value
-  const date = new Date(Number(year), Number(month) - 1, 1)
-  if (isNaN(date.getTime())) return value
-  return date.toLocaleString("en-US", { month: "short", year: "numeric" })
 }
 
 export default function CertificateCard({ cert }: { cert: Certificate }) {

--- a/components/certificates/CertificatesRoadmap.tsx
+++ b/components/certificates/CertificatesRoadmap.tsx
@@ -1,18 +1,10 @@
 import type { Certificate } from "./CertificateCard"
+import { formatMonth, getReadableTextColor } from "@/lib/utils"
 
 const STATUS_LABEL: Record<string, string> = {
   completed: "Completed",
   "in-progress": "In Progress",
   planned: "Planned",
-}
-
-function formatMonth(value: string) {
-  if (!value) return ""
-  const [year, month] = value.split("-")
-  if (!year || !month) return value
-  const date = new Date(Number(year), Number(month) - 1, 1)
-  if (isNaN(date.getTime())) return value
-  return date.toLocaleString("en-US", { month: "short", year: "numeric" })
 }
 
 function parseMonth(value: string): number | null {
@@ -123,11 +115,17 @@ export default function CertificatesRoadmap({
         {entries.map(({ cert, startOffset, span, startLabel, endLabel }) => {
           const left = (startOffset / totalMonths) * 100
           const width = (span / totalMonths) * 100
+          const hasAccent = Boolean(cert.accentColor)
           const fill =
             cert.accentColor ||
             (cert.status === "in-progress"
               ? "var(--primary)"
               : "var(--muted-foreground)")
+          const textColor = hasAccent
+            ? getReadableTextColor(cert.accentColor)
+            : cert.status === "in-progress"
+              ? "var(--primary-foreground)"
+              : "var(--background)"
           return (
             <div
               key={cert.id}
@@ -150,11 +148,9 @@ export default function CertificatesRoadmap({
                     left: `${left}%`,
                     width: `${width}%`,
                     background: fill,
-                    opacity: cert.status === "in-progress" ? 1 : 0.65,
-                    color:
-                      cert.status === "in-progress"
-                        ? "var(--primary-foreground)"
-                        : "var(--background)",
+                    opacity:
+                      hasAccent || cert.status === "in-progress" ? 1 : 0.65,
+                    color: textColor,
                   }}
                 >
                   <span className="truncate">

--- a/components/certificates/CertificatesRoadmap.tsx
+++ b/components/certificates/CertificatesRoadmap.tsx
@@ -1,0 +1,171 @@
+import type { Certificate } from "./CertificateCard"
+
+const STATUS_LABEL: Record<string, string> = {
+  completed: "Completed",
+  "in-progress": "In Progress",
+  planned: "Planned",
+}
+
+function formatMonth(value: string) {
+  if (!value) return ""
+  const [year, month] = value.split("-")
+  if (!year || !month) return value
+  const date = new Date(Number(year), Number(month) - 1, 1)
+  if (isNaN(date.getTime())) return value
+  return date.toLocaleString("en-US", { month: "short", year: "numeric" })
+}
+
+function parseMonth(value: string): number | null {
+  if (!value) return null
+  const [yearStr, monthStr] = value.split("-")
+  const year = Number(yearStr)
+  const month = Number(monthStr)
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return null
+  return year * 12 + (month - 1)
+}
+
+interface RoadmapEntry {
+  cert: Certificate
+  startOffset: number
+  span: number
+  startLabel: string
+  endLabel: string
+}
+
+function buildRoadmap(certs: Certificate[]) {
+  const entries: { cert: Certificate; startIdx: number; endIdx: number }[] = []
+  let min = Number.POSITIVE_INFINITY
+  let max = Number.NEGATIVE_INFINITY
+
+  for (const cert of certs) {
+    if (cert.status === "completed") continue
+    const start = parseMonth(cert.plannedStart)
+    if (start === null) continue
+    const end = parseMonth(cert.plannedEnd) ?? start
+    if (end < start) continue
+    entries.push({ cert, startIdx: start, endIdx: end })
+    if (start < min) min = start
+    if (end > max) max = end
+  }
+
+  if (entries.length === 0) {
+    return { entries: [] as RoadmapEntry[], months: [] as string[] }
+  }
+
+  const totalMonths = max - min + 1
+  const months: string[] = []
+  for (let i = 0; i < totalMonths; i++) {
+    const absolute = min + i
+    const year = Math.floor(absolute / 12)
+    const month = (absolute % 12) + 1
+    const key = `${year}-${String(month).padStart(2, "0")}`
+    months.push(key)
+  }
+
+  const built: RoadmapEntry[] = entries
+    .sort((a, b) => a.startIdx - b.startIdx)
+    .map((e) => ({
+      cert: e.cert,
+      startOffset: e.startIdx - min,
+      span: e.endIdx - e.startIdx + 1,
+      startLabel: formatMonth(e.cert.plannedStart),
+      endLabel: e.cert.plannedEnd ? formatMonth(e.cert.plannedEnd) : "",
+    }))
+
+  return { entries: built, months }
+}
+
+export default function CertificatesRoadmap({
+  certs,
+}: {
+  certs: Certificate[]
+}) {
+  const { entries, months } = buildRoadmap(certs)
+  if (entries.length === 0) return null
+
+  const totalMonths = months.length
+
+  return (
+    <div className="glass rounded-xl p-6 md:p-8">
+      <header className="flex flex-col md:flex-row md:items-baseline md:justify-between gap-2 pb-5 border-b border-border mb-6">
+        <h3 className="font-display text-lg md:text-xl font-semibold tracking-tight">
+          {entries.length} certificate{entries.length !== 1 ? "s" : ""} in motion
+        </h3>
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+          {formatMonth(months[0])} -- {formatMonth(months[months.length - 1])}
+        </p>
+      </header>
+
+      {/* Month grid */}
+      <div
+        className="grid border border-border rounded-lg overflow-hidden text-center"
+        style={{ gridTemplateColumns: `repeat(${totalMonths}, minmax(0, 1fr))` }}
+      >
+        {months.map((m, i) => {
+          const [y, mo] = m.split("-")
+          const date = new Date(Number(y), Number(mo) - 1, 1)
+          return (
+            <div
+              key={m}
+              className="px-1 py-3 font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground border-r border-border last:border-r-0"
+            >
+              <div className="font-display text-sm font-semibold text-foreground">
+                M{i + 1}
+              </div>
+              {date.toLocaleString("en-US", { month: "short" })}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Phase bars */}
+      <div className="mt-6 space-y-3">
+        {entries.map(({ cert, startOffset, span, startLabel, endLabel }) => {
+          const left = (startOffset / totalMonths) * 100
+          const width = (span / totalMonths) * 100
+          const fill =
+            cert.accentColor ||
+            (cert.status === "in-progress"
+              ? "var(--primary)"
+              : "var(--muted-foreground)")
+          return (
+            <div
+              key={cert.id}
+              className="grid grid-cols-1 md:grid-cols-[180px_1fr] items-center gap-3 md:gap-5"
+            >
+              <div className="flex flex-col gap-1 md:text-right">
+                <span className="font-display text-sm font-semibold tracking-tight">
+                  {cert.name}
+                </span>
+                <span className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
+                  {STATUS_LABEL[cert.status] ?? cert.status}
+                  {startLabel && ` · ${startLabel}`}
+                  {endLabel && ` -- ${endLabel}`}
+                </span>
+              </div>
+              <div className="relative h-8 bg-foreground/[0.04] rounded-md overflow-hidden border border-border">
+                <div
+                  className="absolute top-0 bottom-0 flex items-center px-3 text-[10px] font-mono uppercase tracking-[0.12em]"
+                  style={{
+                    left: `${left}%`,
+                    width: `${width}%`,
+                    background: fill,
+                    opacity: cert.status === "in-progress" ? 1 : 0.65,
+                    color:
+                      cert.status === "in-progress"
+                        ? "var(--primary-foreground)"
+                        : "var(--background)",
+                  }}
+                >
+                  <span className="truncate">
+                    {span} mo · {cert.category || cert.provider || cert.name}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,5 +1,5 @@
 import { db } from "./db"
-import { projects, experienceEntries, blogPosts, caseStudies } from "./schema"
+import { projects, experienceEntries, blogPosts, caseStudies, certificates } from "./schema"
 import { eq, asc } from "drizzle-orm"
 
 export async function getProjects() {
@@ -31,4 +31,8 @@ export async function getCaseStudies() {
 export async function getCaseStudyBySlug(slug: string) {
   const results = await db.select().from(caseStudies).where(eq(caseStudies.slug, slug))
   return results[0] ?? null
+}
+
+export async function getCertificates() {
+  return db.select().from(certificates).orderBy(asc(certificates.sortOrder))
 }

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -45,6 +45,29 @@ export const blogPosts = pgTable("blog_posts", {
   image: text("image").notNull().default(""),
 })
 
+export const certificates = pgTable("certificates", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+  fullTitle: text("full_title").notNull().default(""),
+  provider: text("provider").notNull().default(""),
+  category: text("category").notNull().default(""),
+  status: text("status").notNull().default("planned"),
+  description: text("description").notNull().default(""),
+  credentialUrl: text("credential_url").notNull().default(""),
+  credentialId: text("credential_id").notNull().default(""),
+  issueDate: text("issue_date").notNull().default(""),
+  expiryDate: text("expiry_date").notNull().default(""),
+  plannedStart: text("planned_start").notNull().default(""),
+  plannedEnd: text("planned_end").notNull().default(""),
+  estimatedHours: integer("estimated_hours").notNull().default(0),
+  estimatedCost: text("estimated_cost").notNull().default(""),
+  difficulty: integer("difficulty").notNull().default(0),
+  skills: json("skills").$type<string[]>().notNull().default([]),
+  whyPoints: json("why_points").$type<string[]>().notNull().default([]),
+  accentColor: text("accent_color").notNull().default(""),
+  sortOrder: integer("sort_order").notNull().default(0),
+})
+
 export const caseStudies = pgTable("case_studies", {
   id: serial("id").primaryKey(),
   slug: text("slug").notNull().unique(),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,38 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatMonth(value: string): string {
+  if (!value) return ""
+  const [year, month] = value.split("-")
+  if (!year || !month) return value
+  const date = new Date(Number(year), Number(month) - 1, 1)
+  if (isNaN(date.getTime())) return value
+  return date.toLocaleString("en-US", { month: "short", year: "numeric" })
+}
+
+// WCAG-style readable text color picker for arbitrary hex backgrounds.
+// Falls back to white when the input is unparseable so we never render
+// invisible text on a coloured bar.
+export function getReadableTextColor(hex: string): "#0e0e10" | "#ffffff" {
+  if (!hex) return "#ffffff"
+  let h = hex.trim().replace(/^#/, "")
+  if (h.length === 3) {
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("")
+  }
+  if (h.length !== 6 || /[^0-9a-f]/i.test(h)) return "#ffffff"
+  const r = parseInt(h.slice(0, 2), 16)
+  const g = parseInt(h.slice(2, 4), 16)
+  const b = parseInt(h.slice(4, 6), 16)
+  // Relative luminance per WCAG 2.x
+  const toLinear = (channel: number) => {
+    const v = channel / 255
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
+  }
+  const luminance =
+    0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b)
+  return luminance > 0.5 ? "#0e0e10" : "#ffffff"
+}


### PR DESCRIPTION
## Summary

Adds a certificates tracking system to the portfolio:
- Admin CMS to record completed, in-progress, and planned certificates
- Public render of the cards + roadmap on the **Education** subpage (no standalone /certificates page)
- Built in the existing portfolio "Ink & Signal" style (Space Grotesk, JetBrains Mono, glass cards, teal accent, grain overlay)

## What changed

**Data**
- `lib/schema.ts` -- new `certificates` table with: name, fullTitle, provider, category, status (`planned` | `in-progress` | `completed`), description, credentialUrl/Id, issueDate, expiryDate (empty = lifetime), plannedStart/plannedEnd (`YYYY-MM`), estimatedHours, estimatedCost, difficulty (0-5), skills[], whyPoints[], accentColor, sortOrder
- `lib/data.ts` -- `getCertificates()` helper

**Admin**
- `app/admin/certificates/{page,new,[id]/edit}.tsx` -- list + create + edit forms
- `app/api/admin/certificates/{route,[id]/route}.ts` -- GET/POST/PUT/DELETE
- `components/admin/AdminSidebar.tsx` -- new "Certificates" entry with badge icon
- `app/admin/page.tsx` -- dashboard counter + quick action

**Public**
- `app/education/page.tsx` -- added Certificates section (status counters, grouped cards) and Roadmap section (month grid + phase bars). Empty state when nothing is tracked.
- `components/certificates/CertificateCard.tsx` -- reusable card
- `components/certificates/CertificatesRoadmap.tsx` -- reusable timeline (auto-spans from earliest plannedStart to latest plannedEnd of non-completed certs)

## Manual step before merging

The schema needs to be pushed to NeonDB. The repo has no committed `.env.local`, so I could not run this from the agent shell:

```
npm run db:push
```

After that, log into `/admin/certificates` and add entries. Nothing is seeded -- the public page shows an empty-state until you add data.

## Verification

- `npx tsc --noEmit` -- clean
- `npm run lint` -- no warnings or errors